### PR TITLE
fix header item style

### DIFF
--- a/content/static/style.css
+++ b/content/static/style.css
@@ -425,8 +425,11 @@ div#playground .buttons a {
     flex-direction: row;
     width: auto;
   }
+  .Header-menuItem {
+    margin: 0.5rem 0;
+  }
   .Header-menuItem:first-of-type {
-    margin-top: 0;
+    margin-top: 0.5rem;
   }
   .Header-menuItem,
   .Header-menuItem a:link,

--- a/content/static/style.css
+++ b/content/static/style.css
@@ -337,6 +337,7 @@ div#playground .buttons a {
 }
 .Header-menuItem {
   display: inline-flex;
+  margin: 0.5rem 0;
 }
 .Header-menuItem,
 .Header-menuItem a:link,
@@ -424,9 +425,6 @@ div#playground .buttons a {
     display: flex;
     flex-direction: row;
     width: auto;
-  }
-  .Header-menuItem {
-    margin: 0.5rem 0;
   }
   .Header-menuItem:first-of-type {
     margin-top: 0.5rem;

--- a/content/static/style.css
+++ b/content/static/style.css
@@ -450,7 +450,7 @@ div#playground .buttons a {
   }
   .Header-menuItem--search {
     margin-left: 1.5rem;
-    margin-top: 0;
+    margin-top: 0.5rem;
   }
   .HeaderSearch-input {
     min-width: 5.625rem;


### PR DESCRIPTION
Since the doc of go1.6, the default margin-top of list tag has been 0.5rem not 0 by the embedded style, so assert the same style as the embedded one in stylesheet and re-set the default margin-top to the elements with this problem.

Fixes golang/go#33718