### PR TITLE
internal/dl: redirect to downloadBaseURL for GPG signatures

### DIFF
--- a/internal/dl/dl.go
+++ b/internal/dl/dl.go
@@ -336,7 +336,7 @@ func validUser(user string) bool {
 }
 
 var (
-	fileRe  = regexp.MustCompile(`^go[0-9a-z.]+\.[0-9a-z.-]+\.(tar\.gz|pkg|msi|zip)$`)
+	fileRe  = regexp.MustCompile(`^go[0-9a-z.]+\.[0-9a-z.-]+\.(tar\.gz|tar\.gz\.asc|pkg|msi|zip)$`)
 	goGetRe = regexp.MustCompile(`^go[0-9a-z.]+\.[0-9a-z.-]+$`)
 )
 


### PR DESCRIPTION
Fixes golang/go#35717