### PR TITLE
internal/dl fix missing unstable releases when there are newer versions

### DIFF
--- a/internal/dl/dl.go
+++ b/internal/dl/dl.go
@@ -200,7 +200,7 @@ func filesToReleases(fs []File) (stable, unstable, archive []Release) {
 	sort.Sort(fileOrder(fs))
 
 	var r *Release
-	var stableMaj, stableMin int
+	var stableMaj int
 	add := func() {
 		if r == nil {
 			return
@@ -208,12 +208,6 @@ func filesToReleases(fs []File) (stable, unstable, archive []Release) {
 		if !r.Stable {
 			if len(unstable) != 0 {
 				// Only show one (latest) unstable version.
-				return
-			}
-			maj, min, _ := parseVersion(r.Version)
-			if maj < stableMaj || maj == stableMaj && min <= stableMin {
-				// Display unstable version only if newer than the
-				// latest stable release.
 				return
 			}
 			unstable = append(unstable, *r)
@@ -229,7 +223,7 @@ func filesToReleases(fs []File) (stable, unstable, archive []Release) {
 			}
 			if len(stable) == 0 {
 				// Most recent stable version.
-				stableMaj, stableMin, _ = parseVersion(r.Version)
+				stableMaj, _, _ = parseVersion(r.Version)
 				return true
 			}
 			if maj, _, _ := parseVersion(r.Version); maj == stableMaj {

--- a/internal/dl/dl_test.go
+++ b/internal/dl/dl_test.go
@@ -89,7 +89,7 @@ func TestFilesToReleases(t *testing.T) {
 	if got, want := list(stable), "go1.7.4, go1.6.2"; got != want {
 		t.Errorf("stable = %q; want %q", got, want)
 	}
-	if got, want := list(unstable), ""; got != want {
+	if got, want := list(unstable), "go1.5beta1"; got != want {
 		t.Errorf("unstable = %q; want %q", got, want)
 	}
 	if got, want := list(archive), "go1.7, go1.6, go1.5.2, go1.5"; got != want {
@@ -97,15 +97,16 @@ func TestFilesToReleases(t *testing.T) {
 	}
 }
 
-func TestOldUnstableNotShown(t *testing.T) {
+// Unstable betas should show up regardless of newer a stable versons. See golang.org/issue/37581.
+func TestOldUnstableShown(t *testing.T) {
 	fs := []File{
 		{Version: "go1.7.4"},
 		{Version: "go1.7"},
 		{Version: "go1.7beta1"},
 	}
 	_, unstable, _ := filesToReleases(fs)
-	if len(unstable) != 0 {
-		t.Errorf("got unstable, want none")
+	if len(unstable) != 1 {
+		t.Errorf("got no unstable, want one")
 	}
 }
 


### PR DESCRIPTION
internal/dl remove unwanted filtering of older unstable versions.

`https://golang.org/dl/?mode=json&include=all` didn't include unstable versions, as documented in: https://github.com/golang/go/issues/37581. 