### PR TITLE
internal/dl: Redirect sha256 checksum to https://dl.google.com/go

### DIFF
--- a/_content/ref/mod.md
+++ b/_content/ref/mod.md
@@ -1122,6 +1122,7 @@ to create a block.
 use (
     ./my/first/thing
     ./my/second/thing
+)
 ```
 
 The `go` command provides several subcommands for manipulating `go.work` files.


### PR DESCRIPTION
The download of a Go release redirects to https://dl.google.com/go but the download of the same release's sha256 checksum does not. 

For example:

```
$ curl https://golang.org/dl/go1.15.2.linux-amd64.tar.gz
<a
href="https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz">Found</a>.

$ curl https://golang.org/dl/go1.15.2.linux-amd64.tar.gz.sha256
<!DOCTYPE html>
<html>
<head>
<meta name="go-import" content="golang.org/dl git
https://go.googlesource.com/dl">
<meta http-equiv="refresh" content="0;
url=https://golang.org/dl/#go1.15.2.linux-amd64.tar.gz.sha256">
</head>
<body>
Nothing to see here; <a
href="https://golang.org/dl/#go1.15.2.linux-amd64.tar.gz.sha256">move
along</a>.
</body>
</html>

```

The sha256 checksum is avaialbe at https://dl.google.com/go by appending `.sha256` to the end of a release URL:

```
$ curl https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz.sha256
b49fda1ca29a1946d6bb2a5a6982cf07ccd2aba849289508ee0f9918f6bb4552%

```
It would be nice that a release's sha256 can be redirected from https://golang.org/dl to https://dl.google.com/go, the same as its corresponding release. This makes the download of a release and its checksum both accessible from https://golang.org/dl.

To summarize, 

1. :heavy_check_mark: `curl https://golang.org/dl/go1.15.2.linux-amd64.tar.gz -> https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz`
1. :no_entry_sign: `curl https://golang.org/dl/go1.15.2.linux-amd64.tar.gz.sha256 -> curl https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz.sha256`
1. :heavy_check_mark: `curl https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz`
1. :heavy_check_mark: `curl https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz.sha256`

This PR fixes #2 by changing the regexp of the file name matching for redirection.