### PR TITLE
change the download version 1.14.3 to the latest 1.15.6

### DIFF
--- a/content/static/doc/install.html
+++ b/content/static/doc/install.html
@@ -91,7 +91,7 @@
           For example, run the following as root or through <code>sudo</code>:
         </p>
         <pre>
-tar -C /usr/local -xzf <span id="linux-filename">go1.14.3.linux-amd64.tar.gz</span>
+tar -C /usr/local -xzf <span id="linux-filename">go1.15.6.linux-amd64.tar.gz</span>
 </pre
         >
       </li>


### PR DESCRIPTION
When new developers (like me...) copy & paste the code to install go, they may encounter a bug here since the latest version they downloaded is 1.15.6 instead of 1.14.3