### PR TITLE
content/static/doc: make clear when pseudo versions will be used

### DIFF
--- a/content/static/doc/mod.md
+++ b/content/static/doc/mod.md
@@ -139,9 +139,9 @@ A <dfn>pseudo-version</dfn> is a specially formatted
 information about a specific revision in a version control repository. For
 example, `v0.0.0-20191109021931-daa7c04131f5` is a pseudo-version.
 
-Pseudo-versions may refer to revisions for which no [semantic version
-tags](#glos-semantic-version-tag) are available. They may be used to test
-commits before creating version tags, for example, on a development branch.
+Pseudo-versions may refer to revisions for which no canonical version tags are
+available. They may be used to test commits before creating version tags, for
+example, on a development branch.
 
 Each pseudo-version has three parts:
 


### PR DESCRIPTION
The docs is misleading because even if a semantic version tag is
provided, go would also encodes it to a pseudo version format, for
example:
- 1.2.3 is a semantic version tags as per semver spec 2.0[1] which
  go will translate it to a pseudo version.
- v1.2.3 is the canonical version format which go mod love most.

[1]: https://semver.org/spec/v2.0.0.html

Signed-off-by: Hu Keping <hukeping@huawei.com>