### PR TITLE
website: use details instead of toggle divs

### DIFF
--- a/content/static/example.html
+++ b/content/static/example.html
@@ -1,30 +1,27 @@
-<div id="example_{{.Name}}" class="toggle">
-  <div class="collapsed">
-    <p class="exampleHeading toggleButton">▹ <span class="text">Example{{example_suffix .Name}}</span></p>
-  </div>
-  <div class="expanded">
-    <p class="exampleHeading toggleButton">▾ <span class="text">Example{{example_suffix .Name}}</span></p>
-    {{with .Doc}}<p>{{html .}}</p>{{end}}
-    {{$output := .Output}}
-    {{with .Play}}
-      <div class="play">
-        <div class="input"><textarea class="code" spellcheck="false">{{html .}}</textarea></div>
-        <div class="output"><pre>{{html $output}}</pre></div>
-        <div class="buttons">
-          <button class="Button Button--primary run" title="Run this code [shift-enter]">Run</button>
-          <button class="Button fmt" title="Format this code">Format</button>
-          {{if not $.GoogleCN}}
-            <button class="Button share" title="Share this code">Share</button>
-          {{end}}
-        </div>
-      </div>
-    {{else}}
-      <p>Code:</p>
-      <pre class="code">{{.Code}}</pre>
-      {{with .Output}}
-        <p>Output:</p>
-        <pre class="output">{{html .}}</pre>
+<details id="example_{{.Name}}">
+  <summary class="exampleHeading"><span class="text">Example{{example_suffix .Name}}</span></summary>
+  {{with .Doc}}<p>{{html .}}</p>{{end}}
+  {{$output := .Output}}
+  {{with .Play}}
+  <div class="play">
+    <div class="input"><textarea class="code" spellcheck="false">{{html .}}</textarea></div>
+    <div class="output">
+      <pre>{{html $output}}</pre>
+    </div>
+    <div class="buttons">
+      <button class="Button Button--primary run" title="Run this code [shift-enter]">Run</button>
+      <button class="Button fmt" title="Format this code">Format</button>
+      {{if not $.GoogleCN}}
+      <button class="Button share" title="Share this code">Share</button>
       {{end}}
-    {{end}}
+    </div>
   </div>
-</div>
+  {{else}}
+  <p>Code:</p>
+  <pre class="code">{{.Code}}</pre>
+  {{with .Output}}
+  <p>Output:</p>
+  <pre class="output">{{html .}}</pre>
+  {{end}}
+  {{end}}
+</details>

--- a/content/static/godocs.js
+++ b/content/static/godocs.js
@@ -10,12 +10,12 @@
  *  + Bind links to foldable sections (bindToggleLinks)
  */
 
-(function() {
+(function () {
   'use strict';
 
   var headerEl = document.querySelector('.js-header');
   var menuButtonEl = document.querySelector('.js-headerMenuButton');
-  menuButtonEl.addEventListener('click', function(e) {
+  menuButtonEl.addEventListener('click', function (e) {
     e.preventDefault();
     headerEl.classList.toggle('is-active');
     menuButtonEl.setAttribute(
@@ -47,7 +47,7 @@
     var toc_items = [];
     $(nav)
       .nextAll('h2, h3')
-      .each(function() {
+      .each(function () {
         var node = this;
         if (node.id == '') node.id = 'tmp_' + toc_items.length;
         var link = $('<a/>')
@@ -94,59 +94,31 @@
       .append(dl2);
   }
 
-  function bindToggle(el) {
-    $('.toggleButton', el).click(function() {
-      if ($(this).closest('.toggle, .toggleVisible')[0] != el) {
-        // Only trigger the closest toggle header.
-        return;
-      }
-
-      if ($(el).is('.toggle')) {
-        $(el)
-          .addClass('toggleVisible')
-          .removeClass('toggle');
-      } else {
-        $(el)
-          .addClass('toggle')
-          .removeClass('toggleVisible');
-      }
-    });
-  }
-
-  function bindToggles(selector) {
-    $(selector).each(function(i, el) {
-      bindToggle(el);
-    });
-  }
-
-  function bindToggleLink(el, prefix) {
-    $(el).click(function() {
+  function bindToggleLink(el) {
+    $(el).click(function () {
       var href = $(el).attr('href');
-      var i = href.indexOf('#' + prefix);
+      var i = href.indexOf('#');
       if (i < 0) {
         return;
       }
-      var id = '#' + prefix + href.slice(i + 1 + prefix.length);
-      if ($(id).is('.toggle')) {
-        $(id)
-          .find('.toggleButton')
-          .first()
-          .click();
+      if ($(href).is('details')) {
+        $(href).attr('open', 'open')
       }
     });
   }
-  function bindToggleLinks(selector, prefix) {
-    $(selector).each(function(i, el) {
-      bindToggleLink(el, prefix);
+
+  function bindToggleLinks(selector) {
+    $(selector).each(function (i, el) {
+      bindToggleLink(el);
     });
   }
 
   function setupInlinePlayground() {
     'use strict';
     // Set up playground when each element is toggled.
-    $('div.play').each(function(i, el) {
+    $('div.play').each(function (i, el) {
       // Set up playground for this example.
-      var setup = function() {
+      var setup = function () {
         var code = $('.code', el);
         playground({
           codeEl: code,
@@ -158,7 +130,7 @@
         });
 
         // Make the code textarea resize to fit content.
-        var resize = function() {
+        var resize = function () {
           code.height(0);
           var h = code[0].scrollHeight;
           code.height(h + 20); // minimize bouncing.
@@ -179,7 +151,7 @@
       var built = false;
       $(el)
         .closest('.toggle')
-        .click(function() {
+        .click(function () {
           // Only set up once.
           if (!built) {
             setup();
@@ -196,7 +168,7 @@
     page.css('outline', 0); // disable outline when focused
     page.attr('tabindex', -1); // and set tabindex so that it is focusable
     $(window)
-      .resize(function(evt) {
+      .resize(function (evt) {
         // only focus page when the topbar is at fixed position (that is, it's in
         // front of page, and keyboard event will go to the former by default.)
         // by focusing page, keyboard event will go to page so that up/down arrow,
@@ -207,26 +179,13 @@
   }
 
   function toggleHash() {
-    var id = window.location.hash.substring(1);
+    var id = window.location.hash;
     // Open all of the toggles for a particular hash.
-    var els = $(
-      document.getElementById(id),
-      $('a[name]').filter(function() {
-        return $(this).attr('name') == id;
-      })
-    );
-
-    while (els.length) {
-      for (var i = 0; i < els.length; i++) {
-        var el = $(els[i]);
-        if (el.is('.toggle')) {
-          el.find('.toggleButton')
-            .first()
-            .click();
-        }
+    $(id).each(function () {
+      if ($(this).is('details')) {
+        $(this).prop('open', true)
       }
-      els = el.parent();
-    }
+    })
   }
 
   function personalizeInstallInstructions() {
@@ -281,8 +240,8 @@
 
     var message = $(
       '<p class="downloading">' +
-        'Your download should begin shortly. ' +
-        'If it does not, click <a>this link</a>.</p>'
+      'Your download should begin shortly. ' +
+      'If it does not, click <a>this link</a>.</p>'
     );
     message.find('a').attr('href', download);
     message.insertAfter('#nav');
@@ -318,54 +277,50 @@
 
     $('#page .container')
       .find('h2[id], h3[id]')
-      .each(function() {
+      .each(function () {
         var el = $(this);
         addPermalink(el, el);
       });
 
     $('#page .container')
       .find('dl[id]')
-      .each(function() {
+      .each(function () {
         var el = $(this);
         // Add the anchor to the "dt" element.
         addPermalink(el, el.find('> dt').first());
       });
   }
 
-  $('.js-expandAll').click(function() {
+  $('.js-expandAll').click(function () {
     if ($(this).hasClass('collapsed')) {
-      toggleExamples('toggle');
+      toggleExamples(true);
       $(this).text('(Collapse All)');
     } else {
-      toggleExamples('toggleVisible');
+      toggleExamples(false);
       $(this).text('(Expand All)');
     }
     $(this).toggleClass('collapsed');
   });
 
-  function toggleExamples(className) {
+  function toggleExamples(open) {
     // We need to explicitly iterate through divs starting with "example_"
     // to avoid toggling Overview and Index collapsibles.
-    $("[id^='example_']").each(function() {
-      // Check for state and click it only if required.
-      if ($(this).hasClass(className)) {
-        $(this)
-          .find('.toggleButton')
-          .first()
-          .click();
+    $("[id^='example_']").each(function () {
+      if (open) {
+        $(this).prop('open', true);
+      } else {
+        $(this).removeAttr("open");
       }
     });
   }
 
-  $(document).ready(function() {
+  $(document).ready(function () {
     generateTOC();
     addPermalinks();
-    bindToggles('.toggle');
-    bindToggles('.toggleVisible');
-    bindToggleLinks('.exampleLink', 'example_');
-    bindToggleLinks('.overviewLink', '');
-    bindToggleLinks('.examplesLink', '');
-    bindToggleLinks('.indexLink', '');
+    bindToggleLinks('.exampleLink');
+    bindToggleLinks('.overviewLink');
+    bindToggleLinks('.examplesLink');
+    bindToggleLinks('.indexLink');
     setupInlinePlayground();
     fixFocus();
     toggleHash();

--- a/content/static/package.html
+++ b/content/static/package.html
@@ -31,23 +31,18 @@
 			</dl>
 		</div>
 		<!-- The package's Name is printed as title by the top-level template -->
-		<div id="pkg-overview" class="toggleVisible">
-			<div class="collapsed">
-				<h2 class="toggleButton" title="Click to show Overview section">Overview ▹</h2>
-			</div>
-			<div class="expanded">
-				<h2 class="toggleButton" title="Click to hide Overview section">Overview ▾</h2>
-				{{comment_html .Doc}}
-				{{example_html $ ""}}
-			</div>
-		</div>
+		<details id="pkg-overview" open>
+			<summary>
+				<h2 title="Click to show Overview section">Overview</h2>
+			</summary>
+      {{comment_html .Doc}}
+      {{example_html $ ""}}
+		</details>
 
-		<div id="pkg-index" class="toggleVisible">
-		<div class="collapsed">
-			<h2 class="toggleButton" title="Click to show Index section">Index ▹</h2>
-		</div>
-		<div class="expanded">
-			<h2 class="toggleButton" title="Click to hide Index section">Index ▾</h2>
+		<details id="pkg-index" open>
+      <summary class="collapsed">
+        <h2 title="Click to show Index section">Index</h2>
+      </summary>
 
 		<!-- Table of contents for API; must be named manual-nav to turn off auto nav. -->
 			<div id="manual-nav">
@@ -104,8 +99,7 @@
 			</span>
 			</p>
 		{{end}}
-		</div><!-- .expanded -->
-		</div><!-- #pkg-index -->
+		</details><!-- #pkg-index -->
 
 		{{with .Consts}}
 			<h2 id="pkg-constants">Constants</h2>

--- a/content/static/packageroot.html
+++ b/content/static/packageroot.html
@@ -32,12 +32,10 @@
 			</dl>
 		</div>
 
-		<div id="stdlib" class="toggleVisible">
-			<div class="collapsed">
-				<h2 class="toggleButton" title="Click to show Standard library section">Standard library ▹</h2>
-			</div>
-			<div class="expanded">
-				<h2 class="toggleButton" title="Click to hide Standard library section">Standard library ▾</h2>
+		<details id="stdlib" open>
+			<summary>
+				<h2 title="Click to show Standard library section">Standard library</h2>
+			</summary>
 				<img alt="" class="gopher" src="/doc/gopher/pkg.png"/>
 				<div class="pkg-dir">
 					<table>
@@ -68,16 +66,13 @@
 						{{end}}
 					</table>
 				</div> <!-- .pkg-dir -->
-			</div> <!-- .expanded -->
-		</div> <!-- #stdlib .toggleVisible -->
+		</details>
 
 	{{if hasThirdParty .List }}
-		<div id="thirdparty" class="toggleVisible">
-			<div class="collapsed">
-				<h2 class="toggleButton" title="Click to show Third party section">Third party ▹</h2>
-			</div>
-			<div class="expanded">
-				<h2 class="toggleButton" title="Click to hide Third party section">Third party ▾</h2>
+		<details id="thirdparty" open>
+			<summary>
+				<h2 title="Click to show Third party section">Third party</h2>
+			</summary>
 				<div class="pkg-dir">
 					<table>
 						<tr>
@@ -106,9 +101,8 @@
 							</tr>
 						{{end}}
 					</table>
-				</div> <!-- .pkg-dir -->
-			</div> <!-- .expanded -->
-		</div> <!-- #stdlib .toggleVisible -->
+                </div> <!-- .pkg-dir -->
+		</details>
 	{{end}}
 
 	<h2 id="other">Other packages</h2>

--- a/content/static/style.css
+++ b/content/static/style.css
@@ -894,21 +894,6 @@ a#start .desc {
     margin-top: 0;
   }
 }
-.toggleButton {
-  cursor: pointer;
-}
-.toggle > .collapsed {
-  display: block;
-}
-.toggle > .expanded {
-  display: none;
-}
-.toggleVisible > .collapsed {
-  display: none;
-}
-.toggleVisible > .expanded {
-  display: block;
-}
 table.codetable {
   margin-left: auto;
   margin-right: auto;
@@ -1139,4 +1124,18 @@ a.error {
     white-space: pre-wrap;
     page-break-inside: avoid;
   }
+}
+summary {
+    margin: 1.25rem 0 1.25rem;
+    background: #e0ebf5;
+    padding: 0.5rem;
+    cursor: pointer;
+}
+summary.exampleHeading {
+    margin: 1.25rem;
+    background: inherit;
+    padding: 0;
+}
+summary > * {
+    display: inline;
 }

--- a/internal/dl/tmpl.go
+++ b/internal/dl/tmpl.go
@@ -172,15 +172,12 @@ information about Go releases.
 {{end}}
 
 {{with .Archive}}
-<div class="toggle" id="archive">
-  <div class="collapsed">
-    <h3 class="toggleButton" title="Click to show versions">Archived versions ▹</h3>
+<details id="archive">
+  <summary>
+    <h3 title="Click to show versions">Archived versions</h3>
   </div>
-  <div class="expanded">
-    <h3 class="toggleButton" title="Click to hide versions">Archived versions ▾</h3>
-    {{template "releases" .}}
-  </div>
-</div>
+  {{template "releases" .}}
+</details>
 {{end}}
 
 </div><!-- .container -->
@@ -246,23 +243,20 @@ $(document).ready(function() {
 
 {{define "releases"}}
 {{range .}}
-<div class="toggle{{if .Visible}}Visible{{end}}" id="{{.Version}}">
-	<div class="collapsed">
-		<h2 class="toggleButton" title="Click to show downloads for this version">{{.Version}} ▹</h2>
-	</div>
-	<div class="expanded">
-		<h2 class="toggleButton" title="Click to hide downloads for this version">{{.Version}} ▾</h2>
-		{{if .Stable}}{{else}}
-			<p>This is an <b>unstable</b> version of Go. Use with caution.</p>
-			<p>If you already have Go installed, you can install this version by running:</p>
+<details id="{{.Version}}" {{if .Visible}}open{{end}}>
+	<summary>
+		<h2 title="Click to show downloads for this version">{{.Version}}</h2>
+	</summary>
+	{{if .Stable}}{{else}}
+		<p>This is an <b>unstable</b> version of Go. Use with caution.</p>
+		<p>If you already have Go installed, you can install this version by running:</p>
 <pre>
 go get golang.org/dl/{{.Version}}
 </pre>
-			<p>Then, use the <code>{{.Version}}</code> command instead of the <code>go</code> command to use {{.Version}}.</p>
-		{{end}}
-		{{template "files" .}}
-	</div>
-</div>
+		<p>Then, use the <code>{{.Version}}</code> command instead of the <code>go</code> command to use {{.Version}}.</p>
+	{{end}}
+	{{template "files" .}}
+</details>
 {{end}}
 {{end}}
 


### PR DESCRIPTION
Use html details element instead of divs and javascript
to handle togglable parts of the page. This makes
the website more friendly to users with disabled
javascript, simplifies the html, and allows us to
remove a few lines of code from the javascript.

changes:
* use details + summary elements instead of togglable
  divs
* adjust the relevant javascript code that handled
  toggling and automatic opening of togglable divs
  based on url hash

Fixes: https://github.com/golang/go/issues/44000