### PR TITLE
_content/doc/modules: fix typo in gomod-ref.md

### DIFF
--- a/_content/doc/modules/gomod-ref.md
+++ b/_content/doc/modules/gomod-ref.md
@@ -242,7 +242,7 @@ replacement path when resolving the dependency.
   replace example.com/othermodule => example.com/othermodule v1.2.3
   ```
 
-  The following example replaces module version v1.2.5 with version v1.2.5 of
+  The following example replaces module version v1.2.5 with version v1.2.3 of
   the same module.
 
   ```


### PR DESCRIPTION
Fix typo in the description of the sample replace directive.