### PR TITLE
Update call-module-code.html

### DIFF
--- a/_content/doc/tutorial/call-module-code.html
+++ b/_content/doc/tutorial/call-module-code.html
@@ -145,18 +145,17 @@ go 1.14
       </li>
 
       <li>
-        In the hello directory, run <code>go build</code> to make Go locate the
+        In the hello directory, run <code>go get example.com/greetings</code> to make Go locate the
         module and add it as a dependency to the go.mod file.
 
         <pre>
-$ go build
-go: found example.com/greetings in example.com/greetings v0.0.0-00010101000000-000000000000
-</pre
-        >
+$ go get example.com/greetings
+go get: added example.com/greetings v0.0.0-00010101000000-000000000000
+        </pre>
       </li>
 
       <li>
-        Look at go.mod again to see the changes made by <code>go build</code>,
+        Look at go.mod again to see the changes made by <code>go get</code>,
         including the <code>require</code> directive Go added.
 
         <pre>
@@ -194,9 +193,17 @@ replace example.com/greetings => ../greetings
       </li>
     </ol>
   </li>
+    
+  <li>
+      In the <code>hello</code> directory, run <code>go build</code> to make Go compile the module.
+
+        <pre>
+$ go build
+        </pre>
+  </li>
 
   <li>
-    In the <code>hello</code> directory, run the <code>hello</code> executable
+      Still in the <code>hello</code> directory, run the <code>hello</code> executable
     (created by <code>go build</code>) to confirm that the code works.
     <ul>
       <li>


### PR DESCRIPTION
Executing the `go build` command after adding the replace directive fails with the below message. Updated the documentation to add an extra ` go get ` step to resolve the dependency of the greetings module.

```
go build
hello.go:6:2: module example.com/greetings provides package example.com/greetings and is replaced but not required; to add it:
        go get example.com/greetings
```