### PR TITLE
_content/doc: update link to Gophers Discord

### DIFF
--- a/_content/doc/help.html
+++ b/_content/doc/help.html
@@ -27,7 +27,7 @@ The <a href="https://forum.golangbridge.org/">Go Forum</a> is a discussion
 forum for Go programmers.
 </p>
 
-<h3 id="discord"><a href="https://discord.gg/64C346U">Gophers Discord</a></h3>
+<h3 id="discord"><a href="https://discord.gg/golang">Gophers Discord</a></h3>
 <p>
 Get live support and talk with other gophers on the Go Discord.
 </p>


### PR DESCRIPTION
Changed to vanity URL after becoming a Discord Partnered server. 