### PR TITLE
_content/doc/tutorial: highlight all changed parts of the tutorial code

### DIFF
--- a/_content/doc/tutorial/greetings-multiple-people.html
+++ b/_content/doc/tutorial/greetings-multiple-people.html
@@ -156,16 +156,16 @@ func main() {
     log.SetFlags(0)
 
     <ins>// A slice of names.
-    names := []string{"Gladys", "Samantha", "Darrin"}</ins>
+    names := []string{"Gladys", "Samantha", "Darrin"}
 
     // Request greeting messages for the names.
-    messages, err := greetings.Hellos(names)
+    messages, err := greetings.Hellos(names)</ins>
     if err != nil {
         log.Fatal(err)
     }
-    // If no error was returned, print the returned map of
+    <ins>// If no error was returned, print the returned map of
     // messages to the console.
-    fmt.Println(messages)
+    fmt.Println(messages)</ins>
 }
 </pre>
 


### PR DESCRIPTION
This change is a fix for what appears to be a typo.  In the modules tutorial, in [section "Return greetings for multiple people"](https://golang.org/doc/tutorial/greetings-multiple-people), the step 2 code block does not indicate all the changed sections.  

Everything I highlighted needs to changed in order for the code to work as intended.  I found the highlights to be very helpful in following and transcribing the tutorial, so I noticed when they were incorrect.  