### PR TITLE
_content/doc/articles/wiki: update 'OS X' to 'macOS'

### DIFF
--- a/_content/doc/articles/wiki/index.html
+++ b/_content/doc/articles/wiki/index.html
@@ -28,7 +28,7 @@ Assumed knowledge:
 <h2>Getting Started</h2>
 
 <p>
-At present, you need to have a FreeBSD, Linux, OS X, or Windows machine to run Go.
+At present, you need to have a FreeBSD, Linux, macOS, or Windows machine to run Go.
 We will use <code>$</code> to represent the command prompt.
 </p>
 


### PR DESCRIPTION
As macOS is now in version 11, or XI, which Go supports. There is no
need to specify OS X as a prerequisite now, it would be more correct
to specify just 'macOS'.