### PR TITLE
_content/doc/play: fix loop bounds to match function comments

### DIFF
--- a/_content/doc/play/pi.go
+++ b/_content/doc/play/pi.go
@@ -19,11 +19,11 @@ func main() {
 // approximation of pi.
 func pi(n int) float64 {
 	ch := make(chan float64)
-	for k := 0; k <= n; k++ {
+	for k := 0; k < n; k++ {
 		go term(ch, float64(k))
 	}
 	f := 0.0
-	for k := 0; k <= n; k++ {
+	for k := 0; k < n; k++ {
 		f += <-ch
 	}
 	return f


### PR DESCRIPTION
Function comments specify that n go routines are launched, but code
launches n+1. To match comments, launch n go routines instead of n+1.

Fixes golang/go#46223