### PR TITLE
_content/doc: add XMPP channel

### DIFF
--- a/_content/doc/help.html
+++ b/_content/doc/help.html
@@ -38,6 +38,11 @@ Get live support and talk with other gophers on the Go Discord.
 <h3 id="irc"><a href="irc:irc.freenode.net/go-nuts">Go IRC Channel</a></h3>
 <p>Get live support at <b>#go-nuts</b> on <b>irc.freenode.net</b>, the official
 Go IRC channel.</p>
+
+<h3 id="xmpp"><a href="xmpp:go@gopher.chat?join">Go XMPP Channel</a></h3>
+<p>Get live support and discussion on a Go-themed chat server. Join with any
+XMPP/Jabber compatible client or from <a href="https://gopher.chat/">the
+web</a>.</p>
 {{end}}
 
 <h3 id="faq"><a href="/doc/faq">Frequently Asked Questions (FAQ)</a></h3>


### PR DESCRIPTION
Let's add the relatively popular XMPP channel to the list of chats that are linked. The main channel isn't as highly trafficked as the IRC one, but the server has a lot of users and it would be good to provide it as a resource to the broader Go community.