### PR TITLE
Replace freenode.net by libera.chat

### DIFF
--- a/_content/help.html
+++ b/_content/help.html
@@ -34,8 +34,8 @@ Get live support and talk with other gophers on the Go Discord.
 <h3 id="slack"><a href="https://blog.gopheracademy.com/gophers-slack-community/">Gopher Slack</a></h3>
 <p>Get live support from other users in the Go slack channel.</p>
 
-<h3 id="irc"><a href="irc:irc.freenode.net/go-nuts">Go IRC Channel</a></h3>
-<p>Get live support at <b>#go-nuts</b> on <b>irc.freenode.net</b>, the official
+<h3 id="irc"><a href="irc:irc.libera.chat/go-nuts">Go IRC Channel</a></h3>
+<p>Get live support at <b>#go-nuts</b> on <b>irc.libera.chat</b>, the official
 Go IRC channel.</p>
 {{end}}
 


### PR DESCRIPTION
https://lwn.net/Articles/857252/

https://arstechnica.com/gadgets/2021/05/freenode-irc-has-been-taken-over-by-the-crown-prince-of-korea/


Freenode former staff have resigned and moved to libera.chat . 


This patch makes #go-nuts at libera.chat official IRC channel of Golang