### PR TITLE
godoc/style.css: enable horizontal scroll on textarea

### DIFF
--- a/_content/lib/godoc/style.css
+++ b/_content/lib/godoc/style.css
@@ -887,8 +887,10 @@ div.play .input textarea {
   border: none;
   outline: none;
   resize: none;
+  white-space: pre;
+  overflow-x: auto;
 
-  overflow: hidden;
+  overflow-y: hidden;
 }
 div#playground .input textarea {
   overflow: auto;


### PR DESCRIPTION
previously Example codes would wrap around for long lines on smaller screen.