### PR TITLE
_content/.well-known: register libera.chat project

### DIFF
--- a/_content/.well-known/libera/index.html
+++ b/_content/.well-known/libera/index.html
@@ -1,0 +1,1 @@
+I'm registering with Libera libera-registration-ticket=903


### PR DESCRIPTION
The libera.chat folks have asked that we verify our chat room by temporarily (I will make the follow up to remove this) placing this string in the well-known tree. This would allow the `#go-nuts` channel to have certain protections including reservig the name `#go-*` and the ability to continue using the single `#` (instead of the two ##s for unverified channels). Is it possible the Go team would be okay with merging this temporarily? Thank you.

See golang/go#46281

/cc @danderson