### PR TITLE
Update link to documentation

### DIFF
--- a/go.dev/_content/learn/quickstart.yaml
+++ b/go.dev/_content/learn/quickstart.yaml
@@ -2,7 +2,7 @@
     content: Everything there is to know about Go. Get started on a new project
       or brush up for your existing Go code.
     cta: View documentation
-    url: https://golang.org/doc/install
+    url: https://golang.org/doc/
   - title: Tour of Go
     content: An interactive introduction to Go in three sections. Each section
       concludes with a few exercises so you can practice what you've learned.


### PR DESCRIPTION
The description for this link led me to believe that I would end up at a general documentation/reference page, not the installation documentation.  I've updated the link to reflect (what I believe is) the correct URL.

On the rendered page, there's a large "Download" button with a link the the installation instructions predominantly displayed above this link, so I don't think this will prevent users from finding the installation documentation.