### PR TITLE
_content/.well-known: revert register libera.chat project

### DIFF
--- a/_content/.well-known/libera/index.html
+++ b/_content/.well-known/libera/index.html
@@ -1,1 +1,0 @@
-I'm registering with Libera libera-registration-ticket=903


### PR DESCRIPTION
These files were never served correctly but the libera.chat folks have
verified that the CL was merged (and presumably intended to be
displayed) and the project now has all the required permissions.

This reverts commit 7150aade441d21b06ee1a0634f02b985b0a67a95.