### PR TITLE
tour: updated README and welcome article page-3

### DIFF
--- a/tour/README.md
+++ b/tour/README.md
@@ -7,10 +7,11 @@ https://tour.golang.org to start the tour.
 
 ## Download/Install
 
-To install the tour from source, first
-[install Go](https://golang.org/doc/install) and then run:
+To run the tour locally, you'll first need to install
+[Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and
+[Go](https://golang.org/doc/install) and then run:
 
-	$ go get golang.org/x/tour
+	$ go get golang.org/x/website/tour
 
 This will place a `tour` binary in your
 [workspace](https://golang.org/doc/code.html#Workspaces)'s `bin` directory.

--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -67,10 +67,11 @@ Click the [[javascript:highlightAndClick(".next-page")]["next"]] button or type 
 #appengine: without access to the internet. It builds and runs the code samples on
 #appengine: your own machine.
 #appengine:
-#appengine: To run the tour locally, you'll need to first
-#appengine: [[https://golang.org/doc/install][install Go]] and then run:
+#appengine: To run the tour locally, you'll first need to install
+#appengine: [[https://git-scm.com/book/en/v2/Getting-Started-Installing-Git][Git]] and
+#appengine: [[https://golang.org/doc/install][Go]] and then run:
 #appengine:
-#appengine:   go get golang.org/x/tour
+#appengine:   go get golang.org/x/website/tour
 #appengine:
 #appengine: This will place a `tour` binary in your
 #appengine: [[https://golang.org/doc/code.html#Workspaces][workspace]]'s `bin` directory.


### PR DESCRIPTION
Existing README and article has only instructed to install go to use go/tour locally, new change instructs to first install both git and go.
Along with that, new changes also updated latest tour repository.

Fixes: golang/tour#1096