### PR TITLE
tour: added else statement syntax description

### DIFF
--- a/tour/content/flowcontrol.article
+++ b/tour/content/flowcontrol.article
@@ -69,6 +69,10 @@ of the `else` blocks.
 (Both calls to `pow` return their results before the call to `fmt.Println`
 in `main` begins.)
 
+*Note:* Unlike many other languages, Go insists that opening brace of `if` statement should be in same line as `if`.
+Similarly, the `else` must be placed on the same line as the closing brace of the corresponding `if` statement.
+However, opening brace of `else` can be in the new line.
+
 .play flowcontrol/if-and-else.go
 
 * Exercise: Loops and Functions


### PR DESCRIPTION
Existing description does not contain any description related to else statement.
New changes describes syntax for else statement.

Fixes: golang/tour#442