### PR TITLE
tour: added solution repository link on welcome page

### DIFF
--- a/tour/content/welcome.article
+++ b/tour/content/welcome.article
@@ -14,8 +14,9 @@ access by clicking on
 
 You can also view the table of contents at any time by clicking on the [[javascript:highlightAndClick(".nav")][menu]] on the top right of the page.
 
-Throughout the tour you will find a series of slides and exercises for you
-to complete.
+Throughout the tour you will find a series of slides and exercises for you to complete.
+If you get stuck at any point, you can always take a look at the [[https://github.com/golang/website/tree/master/tour/solutions][example solutions]].
+But don't give up too quickly!
 
 You can navigate through them using
 


### PR DESCRIPTION
Existing content does not mention the solution repository link for exercises in tour.
New changes added link of solution to the exercies.

Fixes: golang/tour#542