### PR TITLE
tour: added brief explanation for += operator in flowcontrol/1

### DIFF
--- a/tour/content/flowcontrol.article
+++ b/tour/content/flowcontrol.article
@@ -20,6 +20,10 @@ statement.
 
 The loop will stop iterating once the boolean condition evaluates to `false`.
 
+Additionally, the operator `+=` i.e `addition-assignment` has also been introduced in the given example.
+Operator `+=` adds the value on its right to the variable on its left, and assigns the result to the variable on its left.
+`sum+=i` in the example is equivalent to `sum=sum+i`.
+
 *Note:* Unlike other languages like C, Java, or JavaScript there are no parentheses
 surrounding the three components of the `for` statement and the braces `{`}` are
 always required.


### PR DESCRIPTION
Existing description does not contain any explanation for += operator.
New changes added brief explanation for += operator in flowcontrol/1.

Fixes: golang/tour#436