### PR TITLE
tour: Updated description of struct and added type description in moretypes/2

### DIFF
--- a/tour/content/moretypes.article
+++ b/tour/content/moretypes.article
@@ -31,8 +31,15 @@ Unlike C, Go has no pointer arithmetic.
 
 * Structs
 
-A `struct` is a collection of fields.
+A `struct` is a typed collection of fields. In Go, structs are the way to create user-defined concrete types.
+Syntax to create a struct starts with the keyword `type`, then a name for the struct, followed by the `struct` keyword.
+Inside curly backets, collection of fields are specified with field name and field type.
 
+The `type` keyword is used to define a new type in Go. It is generally referred as [[https://golang.org/ref/spec#Type_definitions][type definition]].
+
+In the given example, a new struct type `Vertex` is created which consist of fields `X` & `Y` of type `int`.
+
+*Note:* Data field in a struct is declared with a known type, which could be a built-in type or a user-defined type.
 .play moretypes/structs.go
 
 * Struct Fields


### PR DESCRIPTION

The existing description didnot explain the type keyword and had less explanation of struct.
New changes added an explanation on struct and type keyword.

Fixes: golang/tour#121