### PR TITLE
Remove "black lives matter" related content

### DIFF
--- a/_content/lib/godoc/site.html
+++ b/_content/lib/godoc/site.html
@@ -34,12 +34,6 @@ window.trackEvent = function(category, action, opt_label, opt_value, opt_noninte
 
 <body class="Site">
 <header class="Header js-header">
-  <div class="Header-banner">
-    Black Lives Matter.
-    <a href="https://support.eji.org/give/153413/#!/donation/checkout"
-       target="_blank"
-       rel="noopener">Support the Equal Justice Initiative.</a>
-  </div>
   <nav class="Header-nav {{if .Title}}Header-nav--wide{{end}}">
     <a href="/"><img class="Header-logo" src="/lib/godoc/images/go-logo-blue.svg" alt="Go"></a>
     <button class="Header-menuButton js-headerMenuButton" aria-label="Main menu" aria-expanded="false">

--- a/blog/_template/root.tmpl
+++ b/blog/_template/root.tmpl
@@ -92,12 +92,6 @@
 </style>
 <body class="Site">
   <header class="Header js-header">
-    <div class="Header-banner">
-      Black Lives Matter.
-      <a href="https://support.eji.org/give/153413/#!/donation/checkout"
-        target="_blank"
-        rel="noopener">Support the Equal Justice Initiative.</a>
-    </div>
     <nav class="Header-nav">
       <a href="{{.GodocURL}}"><img class="Header-logo" src="/lib/godoc/images/go-logo-blue.svg" alt="Go"></a>
       <button class="Header-menuButton js-headerMenuButton" aria-label="Main menu" aria-expanded="false">

--- a/go.dev/_templates/layouts/site.tmpl
+++ b/go.dev/_templates/layouts/site.tmpl
@@ -36,17 +36,6 @@
 
 {{$menus := data "menus"}}
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/about/index.html
+++ b/go.dev/testdata/golden/about/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/categories/index.html
+++ b/go.dev/testdata/golden/categories/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/copyright/index.html
+++ b/go.dev/testdata/golden/copyright/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/index.html
+++ b/go.dev/testdata/golden/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/learn/index.html
+++ b/go.dev/testdata/golden/learn/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/series/case-studies/index.html
+++ b/go.dev/testdata/golden/series/case-studies/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/series/index.html
+++ b/go.dev/testdata/golden/series/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/series/use-cases/index.html
+++ b/go.dev/testdata/golden/series/use-cases/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/americanexpress/index.html
+++ b/go.dev/testdata/golden/solutions/americanexpress/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/armut/index.html
+++ b/go.dev/testdata/golden/solutions/armut/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/capital-one/index.html
+++ b/go.dev/testdata/golden/solutions/capital-one/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/clis/index.html
+++ b/go.dev/testdata/golden/solutions/clis/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/cloud/index.html
+++ b/go.dev/testdata/golden/solutions/cloud/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/cloudflare/index.html
+++ b/go.dev/testdata/golden/solutions/cloudflare/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/cockroachlabs/index.html
+++ b/go.dev/testdata/golden/solutions/cockroachlabs/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/curve/index.html
+++ b/go.dev/testdata/golden/solutions/curve/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/devops/index.html
+++ b/go.dev/testdata/golden/solutions/devops/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/dropbox/index.html
+++ b/go.dev/testdata/golden/solutions/dropbox/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/facebook/index.html
+++ b/go.dev/testdata/golden/solutions/facebook/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/google/chrome/index.html
+++ b/go.dev/testdata/golden/solutions/google/chrome/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/google/coredata/index.html
+++ b/go.dev/testdata/golden/solutions/google/coredata/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/google/firebase/index.html
+++ b/go.dev/testdata/golden/solutions/google/firebase/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/google/index.html
+++ b/go.dev/testdata/golden/solutions/google/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/google/sitereliability/index.html
+++ b/go.dev/testdata/golden/solutions/google/sitereliability/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/grail/index.html
+++ b/go.dev/testdata/golden/solutions/grail/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/index.html
+++ b/go.dev/testdata/golden/solutions/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/mercadolibre/index.html
+++ b/go.dev/testdata/golden/solutions/mercadolibre/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/microsoft/index.html
+++ b/go.dev/testdata/golden/solutions/microsoft/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/netflix/index.html
+++ b/go.dev/testdata/golden/solutions/netflix/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/paypal/index.html
+++ b/go.dev/testdata/golden/solutions/paypal/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/riotgames/index.html
+++ b/go.dev/testdata/golden/solutions/riotgames/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/salesforce/index.html
+++ b/go.dev/testdata/golden/solutions/salesforce/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/target/index.html
+++ b/go.dev/testdata/golden/solutions/target/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/twitch/index.html
+++ b/go.dev/testdata/golden/solutions/twitch/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/twitter/index.html
+++ b/go.dev/testdata/golden/solutions/twitter/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/uber/index.html
+++ b/go.dev/testdata/golden/solutions/uber/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/webdev/index.html
+++ b/go.dev/testdata/golden/solutions/webdev/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/solutions/wildlifestudios/index.html
+++ b/go.dev/testdata/golden/solutions/wildlifestudios/index.html
@@ -32,17 +32,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/tags/index.html
+++ b/go.dev/testdata/golden/tags/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">

--- a/go.dev/testdata/golden/tos/index.html
+++ b/go.dev/testdata/golden/tos/index.html
@@ -31,17 +31,6 @@
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <header class="Site-header js-siteHeader">
-  <div class="Banner">
-    <div class="Banner-inner">
-      <div class="Banner-message">Black Lives Matter</div>
-      <a class="Banner-action"
-         href="https://support.eji.org/give/153413/#!/donation/checkout"
-         target="_blank"
-         rel="noopener">
-         Support the Equal Justice Initiative
-      </a>
-    </div>
-  </div>
   <div class="Header Header--dark">
     <nav class="Header-nav">
       <a href="https://go.dev/">


### PR DESCRIPTION
This change removes the "black lives matter" banners from the website. This site is not - or at least should not be - a political platform and as such it should be free from divisive [1] political content which does not bear any relation to the site subject.

[1] the black lives matter monicker is divisive since the term can be interpreted in many ways, some of which are clearly insulting while others promote a totalitarian ideology.