### PR TITLE
internal/web: stop double-escaping of code in non-playground examples

### DIFF
--- a/cmd/golangorg/testdata/web.txt
+++ b/cmd/golangorg/testdata/web.txt
@@ -151,3 +151,9 @@ GET https://golang.org/x/net
 code == 200
 body contains <meta name="go-import" content="golang.org/x/net git https://go.googlesource.com/net">
 body !contains UA-
+
+GET https://golang.org/pkg/crypto/rsa/?m=old
+body contains []byte(&#34;orders&#34;)
+body !contains []byte(&amp;#34;orders&amp;#34;)
+body contains <span class="comment">
+body !contains &lt;span class=&#34;comment&#34;&gt;

--- a/internal/web/examplefuncs.go
+++ b/internal/web/examplefuncs.go
@@ -74,9 +74,10 @@ func (p *Page) Example(funcName string) template.HTML {
 
 		newPage := *p
 		newPage.Data = struct {
-			Name, Doc, Code, Play, Output string
+			Name, Doc, Play, Output string
+			Code                    template.HTML
 		}{
-			eg.Name, eg.Doc, code, play, out,
+			eg.Name, eg.Doc, play, out, template.HTML(code),
 		}
 		err := t.Execute(&buf, &newPage)
 		if err != nil {


### PR DESCRIPTION
CL 317655 introduced an issue causing non-playground code examples
to be double-escaped, causing HTML escape sequences and elements
to appear in the code, such as the examples in crypto/rsa,
as reported in golang/go#46839. This change treats the code as
template.HTML rather than string after running through (*Page).Node
(which formats the code as HTML) and doing some basic transformations,
preventing this double-escaping from occurring.

Fixes golang/go#46839