### PR TITLE
x/website: remove unnecessary re-prefix in breadcrumb

### DIFF
--- a/_content/site.tmpl
+++ b/_content/site.tmpl
@@ -64,11 +64,8 @@ window.trackEvent = function(category, action, opt_label, opt_value, opt_noninte
 {{define "breadcrumb"}}
   {{$elems := strings.Split (strings.Trim . "/") "/"}}
   {{$prefix := slice $elems 0 (sub (len $elems) 1)}}
-  {{if strings.HasSuffix . "/"}}
-    {{$prefix = slice $elems 0 (sub (len $elems) 2)}}
-  {{end}}
   {{range $i, $elem := $prefix -}}
-    <a href="/{{strings.Join (slice $prefix 0 (add $i 1)) "/"}}">{{$elem}}</a>/
+    <a href="/{{strings.Join (slice $prefix 0 (add $i 1)) "/"}}/">{{$elem}}</a>/
   {{- end -}}
   <span class="text-muted">{{strings.Join (slice $elems (len $prefix) (len $elems)) "/"}}</span>
 {{end}}


### PR DESCRIPTION
Since we now use strings.Trim on the URL, there should be no need to check for suffix.
This change also adds a trailing / to the breadcrumb URL. 
This shouldn't have much effect on the site, however for local development 
non-trailing-slash paths redirected to the actual site, 
which was sometimes confusing to encounter when testing changes.

Fixes https://github.com/golang/go/issues/47761
