### PR TITLE
fix for hamburger button on blog page

### DIFF
--- a/_content/lib/godoc/godocs.js
+++ b/_content/lib/godoc/godocs.js
@@ -16,8 +16,8 @@
   var headerEl = document.querySelector('.js-header');
   var menuButtonEl = document.querySelector('.js-headerMenuButton');
   
-  const path = window.location.pathname
-  if (!path.includes("/blog/") && path.includes("/doc/")) {
+  const path = window.location.pathname;
+  if (path.indexOf("/blog/") == -1 && path.indexOf("/doc/") != -1) {
     menuButtonEl.addEventListener('click', function(e) {
       e.preventDefault();
       headerEl.classList.toggle('is-active');

--- a/_content/lib/godoc/godocs.js
+++ b/_content/lib/godoc/godocs.js
@@ -15,14 +15,18 @@
 
   var headerEl = document.querySelector('.js-header');
   var menuButtonEl = document.querySelector('.js-headerMenuButton');
-  menuButtonEl.addEventListener('click', function(e) {
-    e.preventDefault();
-    headerEl.classList.toggle('is-active');
-    menuButtonEl.setAttribute(
-      'aria-expanded',
-      headerEl.classList.contains('is-active')
-    );
-  });
+  
+  const path = window.location.pathname
+  if (!path.includes("/blog/") && path.includes("/doc/")) {
+    menuButtonEl.addEventListener('click', function(e) {
+      e.preventDefault();
+      headerEl.classList.toggle('is-active');
+      menuButtonEl.setAttribute(
+        'aria-expanded',
+        headerEl.classList.contains('is-active')
+      );
+    });
+  }
 
   /* Generates a table of contents: looks for h2 and h3 elements and generates
    * links. "Decorates" the element with id=="nav" with this table of contents.

--- a/go.dev/_content/js/godocs.js
+++ b/go.dev/_content/js/godocs.js
@@ -16,8 +16,8 @@
   var headerEl = document.querySelector('.js-header');
   var menuButtonEl = document.querySelector('.js-headerMenuButton');
 
-  const path = window.location.pathname
-  if (!path.includes("/blog/") && path.includes("/doc/")) {
+  const path = window.location.pathname;
+  if (path.indexOf("/blog/") == -1 && path.indexOf("/doc/") != -1) {
     menuButtonEl.addEventListener('click', function(e) {
       e.preventDefault();
       headerEl.classList.toggle('is-active');

--- a/go.dev/_content/js/godocs.js
+++ b/go.dev/_content/js/godocs.js
@@ -15,14 +15,18 @@
 
   var headerEl = document.querySelector('.js-header');
   var menuButtonEl = document.querySelector('.js-headerMenuButton');
-  menuButtonEl.addEventListener('click', function(e) {
-    e.preventDefault();
-    headerEl.classList.toggle('is-active');
-    menuButtonEl.setAttribute(
-      'aria-expanded',
-      headerEl.classList.contains('is-active')
-    );
-  });
+
+  const path = window.location.pathname
+  if (!path.includes("/blog/") && path.includes("/doc/")) {
+    menuButtonEl.addEventListener('click', function(e) {
+      e.preventDefault();
+      headerEl.classList.toggle('is-active');
+      menuButtonEl.setAttribute(
+        'aria-expanded',
+        headerEl.classList.contains('is-active')
+      );
+    });
+  }
 
   /* Generates a table of contents: looks for h2 and h3 elements and generates
    * links. "Decorates" the element with id=="nav" with this table of contents.


### PR DESCRIPTION
1.  What version of Go are you using (`go version`)?
Go 1.17

2.  What operating system and processor architecture are you using?
Debian ARM64

3.  What did you do?
I fixed the hamburger menu that doesn't work on blog pages due to the double registration of event listener on hamburger button

4.  What did you expect to see?
I expect to see working hamburger menu on https://go.dev/blog/tidy-web and https://go.dev/blog/*

5.  What did you see instead?
Right now I am seeing non-working hamburger button on /blog urls which is caused by 2 different jquery files getting registered as event listeners.

This is from site.js
```javascript
const menuButtons = document.querySelectorAll('.js-headerMenuButton');
    menuButtons.forEach(button => {
      button.addEventListener('click', e => {
        e.preventDefault();
        header.classList.toggle('is-active');
        button.setAttribute(
          'aria-expanded',
          header.classList.contains('is-active')
        );
      });
    });
```

This is from godocs.js
```javascript
 var menuButtonEl = document.querySelector('.js-headerMenuButton');
  menuButtonEl.addEventListener('click', function(e) {
    e.preventDefault();
    headerEl.classList.toggle('is-active');
    menuButtonEl.setAttribute(
      'aria-expanded',
      headerEl.classList.contains('is-active')
    );
```

![godev-blog-double-event-listener](https://user-images.githubusercontent.com/22800416/129985258-68e1a9c8-f606-41b6-a22d-d9e535af23a9.png)

Note: I tried to take out godocs.js from /blog pages but I am stunned by the complexity of default.tmpl so not sure which pages use which template. Open to any directions but this one is a non-DRY easy dirty-fix



