### PR TITLE
Update go-get-install-deprecation.md fix link href

### DIFF
--- a/_content/doc/go-get-install-deprecation.md
+++ b/_content/doc/go-get-install-deprecation.md
@@ -42,7 +42,7 @@ version. If that module has a `go.mod` file, it must not contain directives like
 `replace` or `exclude` that would cause it to be interpreted differently if it
 were the main module.
 
-See [`go install`](#/ref/mod#go-install) for details.
+See [`go install`](https://golang.org/ref/mod#go-install) for details.
 
 ## Why this is happening
 


### PR DESCRIPTION
Hello Go Team,

Description:
I believe I have identified a small change to correct a link href on this page.  This PR updates the link href for "go install" to specify the full path to the Go Modules Reference at golang.org.

Discovery:
I recently read the post at https://golang.org/doc/go-get-install-deprecation and was attempting to follow the link at the end of the "What to use instead" section and instead of navigating to a new page I remained on the same page with an updated url: https://golang.org/doc/go-get-install-deprecation#/ref/mod#go-install.

Goal:
My goal is to improve consistency in the documentation.  I noticed the documentation at pkg.go.dev also links to the same page which can be verified at https://pkg.go.dev/cmd/go#hdr-Add_dependencies_to_current_module_and_install_them.  This makes me confident that this is the intended url.

Thank you for your time,
Matt