### PR TITLE
cmd/golangorg: add missing /dl/ redirect on tip.golang.org

### DIFF
--- a/cmd/golangorg/server.go
+++ b/cmd/golangorg/server.go
@@ -206,6 +206,7 @@ func NewHandler(contentDir, goroot string) http.Handler {
 	// Register a redirect handler for /dl/ to the golang.org download page.
 	// (golang.org/dl and golang.google.cn/dl are registered separately.)
 	mux.Handle("/dl/", http.RedirectHandler("https://golang.org/dl/", http.StatusFound))
+	mux.Handle("tip.golang.org/dl/", http.RedirectHandler("https://golang.org/dl/", http.StatusFound))
 
 	godev, err := godevHandler(godevFS)
 	if err != nil {

--- a/cmd/golangorg/testdata/web.txt
+++ b/cmd/golangorg/testdata/web.txt
@@ -103,6 +103,9 @@ redirect == https://pkg.go.dev/std
 GET https://tip.golang.org/pkg/
 redirect == https://pkg.go.dev/std@master
 
+GET https://tip.golang.org/dl/
+redirect == https://golang.org/dl/
+
 GET https://golang.org/pkg?m=old
 redirect == /pkg/?m=old
 


### PR DESCRIPTION
Due to a missing redirect there is unfortunately 
a 404 when trying to download golang from 
the subdomain tip.golang.org.