### PR TITLE
cmd/golangorg: fix Content Security Policy breaks embedded YouTube videos

### DIFF
--- a/cmd/golangorg/csp.go
+++ b/cmd/golangorg/csp.go
@@ -71,7 +71,7 @@ var csp = map[string][]string{
 		"feedback.googleusercontent.com",
 		"www.googletagmanager.com",
 		"scone-pa.clients6.google.com",
-		"https://www.youtube.com",
+		"www.youtube.com",
 	},
 	"img-src": {
 		self,

--- a/cmd/golangorg/csp.go
+++ b/cmd/golangorg/csp.go
@@ -71,6 +71,7 @@ var csp = map[string][]string{
 		"feedback.googleusercontent.com",
 		"www.googletagmanager.com",
 		"scone-pa.clients6.google.com",
+		"https://www.youtube.com",
 	},
 	"img-src": {
 		self,


### PR DESCRIPTION
Fixes: golang/go#47973