### PR TITLE
Replace `ioutil` with `os`  package in wiki article

### DIFF
--- a/_content/doc/articles/wiki/final-noclosure.go
+++ b/_content/doc/articles/wiki/final-noclosure.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/_content/doc/articles/wiki/final-noclosure.go
+++ b/_content/doc/articles/wiki/final-noclosure.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main
@@ -9,9 +10,9 @@ package main
 import (
 	"errors"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"regexp"
 )
 
@@ -22,12 +23,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/final-noerror.go
+++ b/_content/doc/articles/wiki/final-noerror.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/_content/doc/articles/wiki/final-noerror.go
+++ b/_content/doc/articles/wiki/final-noerror.go
@@ -2,15 +2,16 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 )
 
 type Page struct {
@@ -20,12 +21,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/final-parsetemplate.go
+++ b/_content/doc/articles/wiki/final-parsetemplate.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"html/template"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 	"regexp"
@@ -21,12 +21,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/final-parsetemplate.go
+++ b/_content/doc/articles/wiki/final-parsetemplate.go
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+//go:build ignore
 
 package main
 
 import (
 	"html/template"
-	"os"
 	"log"
 	"net/http"
+	"os"
 	"regexp"
 )
 

--- a/_content/doc/articles/wiki/final-template.go
+++ b/_content/doc/articles/wiki/final-template.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"html/template"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 )
@@ -20,12 +20,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/final-template.go
+++ b/_content/doc/articles/wiki/final-template.go
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+//go:build ignore
 
 package main
 
 import (
 	"html/template"
-	"os"
 	"log"
 	"net/http"
+	"os"
 )
 
 type Page struct {

--- a/_content/doc/articles/wiki/final.go
+++ b/_content/doc/articles/wiki/final.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"html/template"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 	"regexp"
@@ -21,12 +21,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/final.go
+++ b/_content/doc/articles/wiki/final.go
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+//go:build ignore
 
 package main
 
 import (
 	"html/template"
-	"os"
 	"log"
 	"net/http"
+	"os"
 	"regexp"
 )
 

--- a/_content/doc/articles/wiki/final_test.go
+++ b/_content/doc/articles/wiki/final_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+//go:build ignore
 
 package main
 

--- a/_content/doc/articles/wiki/http-sample.go
+++ b/_content/doc/articles/wiki/http-sample.go
@@ -1,4 +1,4 @@
-// +build ignore
+//go:build ignore
 
 package main
 

--- a/_content/doc/articles/wiki/index.html
+++ b/_content/doc/articles/wiki/index.html
@@ -55,12 +55,12 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 </pre>
 
 <p>
-We import the <code>fmt</code> and <code>ioutil</code> packages from the Go
+We import the <code>fmt</code> and <code>io</code> packages from the Go
 standard library. Later, as we implement additional functionality, we will
 add more packages to this <code>import</code> declaration.
 </p>
@@ -136,7 +136,7 @@ title and body values.
 
 <p>
 Functions can return multiple values. The standard library function
-<code>io.ReadFile</code> returns <code>[]byte</code> and <code>error</code>.
+<code>os.ReadFile</code> returns <code>[]byte</code> and <code>error</code>.
 In <code>loadPage</code>, error isn't being handled yet; the "blank identifier"
 represented by the underscore (<code>_</code>) symbol is used to throw away the
 error return value (in essence, assigning the value to nothing).
@@ -256,7 +256,7 @@ To use the <code>net/http</code> package, it must be imported:
 <pre>
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"log"
 	<b>"net/http"</b>
 )
@@ -372,7 +372,7 @@ also won't be using <code>fmt</code> anymore, so we have to remove that.
 <pre>
 import (
 	<b>"html/template"</b>
-	"io/ioutil"
+	"os"
 	"net/http"
 )
 </pre>

--- a/_content/doc/articles/wiki/index.html
+++ b/_content/doc/articles/wiki/index.html
@@ -60,7 +60,7 @@ import (
 </pre>
 
 <p>
-We import the <code>fmt</code> and <code>io</code> packages from the Go
+We import the <code>fmt</code> and <code>os</code> packages from the Go
 standard library. Later, as we implement additional functionality, we will
 add more packages to this <code>import</code> declaration.
 </p>

--- a/_content/doc/articles/wiki/notemplate.go
+++ b/_content/doc/articles/wiki/notemplate.go
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+//go:build ignore
 
 package main
 
 import (
 	"fmt"
-	"os"
 	"log"
 	"net/http"
+	"os"
 )
 
 type Page struct {

--- a/_content/doc/articles/wiki/notemplate.go
+++ b/_content/doc/articles/wiki/notemplate.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 )
@@ -20,12 +20,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/part1-noerror.go
+++ b/_content/doc/articles/wiki/part1-noerror.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/_content/doc/articles/wiki/part1-noerror.go
+++ b/_content/doc/articles/wiki/part1-noerror.go
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 type Page struct {
@@ -18,12 +19,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) *Page {
 	filename := title + ".txt"
-	body, _ := ioutil.ReadFile(filename)
+	body, _ := os.ReadFile(filename)
 	return &Page{Title: title, Body: body}
 }
 

--- a/_content/doc/articles/wiki/part1.go
+++ b/_content/doc/articles/wiki/part1.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+//go:build ignore
 
 package main
 

--- a/_content/doc/articles/wiki/part1.go
+++ b/_content/doc/articles/wiki/part1.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 type Page struct {
@@ -18,12 +18,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/part2.go
+++ b/_content/doc/articles/wiki/part2.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/_content/doc/articles/wiki/part2.go
+++ b/_content/doc/articles/wiki/part2.go
@@ -2,15 +2,16 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 )
 
 type Page struct {
@@ -20,12 +21,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/part3-errorhandling.go
+++ b/_content/doc/articles/wiki/part3-errorhandling.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/_content/doc/articles/wiki/part3-errorhandling.go
+++ b/_content/doc/articles/wiki/part3-errorhandling.go
@@ -2,15 +2,16 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 package main
 
 import (
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 )
 
 type Page struct {
@@ -20,12 +21,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/part3.go
+++ b/_content/doc/articles/wiki/part3.go
@@ -8,7 +8,7 @@ package main
 
 import (
 	"html/template"
-	"io/ioutil"
+	"os"
 	"log"
 	"net/http"
 )
@@ -20,12 +20,12 @@ type Page struct {
 
 func (p *Page) save() error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(title string) (*Page, error) {
 	filename := title + ".txt"
-	body, err := ioutil.ReadFile(filename)
+	body, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/_content/doc/articles/wiki/part3.go
+++ b/_content/doc/articles/wiki/part3.go
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
+//go:build ignore
 
 package main
 
 import (
 	"html/template"
-	"os"
 	"log"
 	"net/http"
+	"os"
 )
 
 type Page struct {


### PR DESCRIPTION
In Go 1.16 we deprecated `ioutil` https://golang.org/doc/go1.16#ioutil package. I'm updating the wiki blog post to use the new API instead.