### PR TITLE
go.dev/_content/blog: fix embedded videos in two posts

### DIFF
--- a/cmd/golangorg/csp.go
+++ b/cmd/golangorg/csp.go
@@ -73,6 +73,7 @@ var csp = map[string][]string{
 		"www.googletagmanager.com",
 		"scone-pa.clients6.google.com",
 		"www.youtube.com",
+		"player.vimeo.com",
 	},
 	"img-src": {
 		self,

--- a/go.dev/_content/blog/waza-talk.md
+++ b/go.dev/_content/blog/waza-talk.md
@@ -27,7 +27,7 @@ Waza conference entitled
 [_Concurrency is not parallelism_](https://blog.heroku.com/concurrency_is_not_parallelism),
 and a video recording of the talk was released a few months ago.
 
-{{video "https://www.youtube.com/watch?v=oV9rvDllKEg" 500 281}}
+{{video "https://www.youtube.com/embed/oV9rvDllKEg" 500 281}}
 
 The slides are available at [talks.golang.org](https://talks.golang.org/2012/waza.slide)
 (use the left and right arrow keys to navigate).


### PR DESCRIPTION
Fixes golang/go#48235