### PR TITLE
Fix broken link

### DIFF
--- a/_content/doc/effective_go.html
+++ b/_content/doc/effective_go.html
@@ -44,7 +44,7 @@ use the language.
 Moreover, many of the packages contain working, self-contained
 executable examples you can run directly from the
 <a href="//golang.org">golang.org</a> web site, such as
-<a href="//golang.org/pkg/strings/#example_Map">this one</a> (if
+<a href="//golang.org/pkg/strings/#example-Map">this one</a> (if
 necessary, click on the word "Example" to open it up).
 If you have a question about how to approach a problem or how something
 might be implemented, the documentation, code and examples in the


### PR DESCRIPTION
link to example has wrong tag (underscore instead of hyphen)