### PR TITLE
_content/doc: fix the database transactions example

### DIFF
--- a/_content/doc/database/execute-transactions.md
+++ b/_content/doc/database/execute-transactions.md
@@ -114,7 +114,7 @@ func CreateOrder(ctx context.Context, albumID, quantity, custID int) (orderID in
 
 	// Create a helper function for preparing failure results.
 	fail := func(err error) (int64, error) {
-		return fmt.Errorf("CreateOrder: %v", err)
+		return 0, fmt.Errorf("CreateOrder: %v", err)
 	}
 
 	// Get a Tx for making transaction requests.
@@ -152,7 +152,7 @@ func CreateOrder(ctx context.Context, albumID, quantity, custID int) (orderID in
 		return fail(err)
 	}
 	// Get the ID of the order item just created.
-	orderID, err := result.LastInsertId()
+	orderID, err = result.LastInsertId()
 	if err != nil {
 		return fail(err)
 	}


### PR DESCRIPTION
Before this patch, the database transactions example would not compile.

Here is the example before the patch with the import/main func added in order to compile:

```golang
package main

import (
	"context"
	"database/sql"
	"fmt"
	"time"
)

var db *sql.DB

func main() {}

// CreateOrder creates an order for an album and returns the new order ID.
func CreateOrder(ctx context.Context, albumID, quantity, custID int) (orderID int64, err error) {

	// Create a helper function for preparing failure results.
	fail := func(err error) (int64, error) {
		return fmt.Errorf("CreateOrder: %v", err)
	}

	// Get a Tx for making transaction requests.
	tx, err := db.BeginTx(ctx, nil)
	if err != nil {
		return fail(err)
	}
	// Defer a rollback in case anything fails.
	defer tx.Rollback()

	// Confirm that album inventory is enough for the order.
	var enough bool
	if err = tx.QueryRowContext(ctx, "SELECT (quantity >= ?) from album where id = ?",
		quantity, albumID).Scan(&enough); err != nil {
		if err == sql.ErrNoRows {
			return fail(fmt.Errorf("no such album"))
		}
		return fail(err)
	}
	if !enough {
		return fail(fmt.Errorf("not enough inventory"))
	}

	// Update the album inventory to remove the quantity in the order.
	_, err = tx.ExecContext(ctx, "UPDATE album SET quantity = quantity - ? WHERE id = ?",
		quantity, albumID)
	if err != nil {
		return fail(err)
	}

	// Create a new row in the album_order table.
	result, err := tx.ExecContext(ctx, "INSERT INTO album_order (album_id, cust_id, quantity, date) VALUES (?, ?, ?, ?)",
		albumID, custID, quantity, time.Now())
	if err != nil {
		return fail(err)
	}
	// Get the ID of the order item just created.
	orderID, err := result.LastInsertId()
	if err != nil {
		return fail(err)
	}

	// Commit the transaction.
	if err = tx.Commit(); err != nil {
		return fail(err)
	}

	// Return the order ID.
	return orderID, nil
}
```

Trying to compile it yield the following errors (addressed by this PR):

```console
./execute-transactions-example.go:19:3: not enough arguments to return
	have (error)
	want (int64, error)
./execute-transactions-example.go:57:15: no new variables on left side of :=
```