### PR TITLE
link faq page to private repositories page information

### DIFF
--- a/_content/doc/faq.html
+++ b/_content/doc/faq.html
@@ -1313,6 +1313,11 @@ add these lines to your <code>~/.gitconfig</code>:
 	insteadOf = https://github.com/
 </pre>
 
+<p>
+If you are using private repositories make sure to check the
+<a href="https://golang.org/ref/mod#private-modules">private modules page</a>.
+</p>
+
 <h3 id="get_version">
 How should I manage package versions using "go get"?</h3>
 


### PR DESCRIPTION
When working with modules and private repositories `go get` command fails and in it's output we get a message pointing to the [faq page](https://golang.org/doc/faq#git_https). Below is the message:

`If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.`

This PR links the information around [Private modules](https://golang.org/ref/mod#private-modules) to the faq page. 

This issue was faced by several people as you can see from the total number of reactions in this [article](https://medium.com/mabar/today-i-learned-fix-go-get-private-repository-return-error-reading-sum-golang-org-lookup-93058a058dd8). 

With this PR I hope to save time to a lot of people.