### PR TITLE
_content/doc/modules: fixing import statement

### DIFF
--- a/_content/doc/modules/major-version.md
+++ b/_content/doc/modules/major-version.md
@@ -82,6 +82,6 @@ the source for your new version:
 * In your Go code, update every imported package path where you import a package
   from the module, appending the major version number to the module path portion.
   * Old import statement: `import "example.com/mymodule/package1"`
-  * New import statement: `import "example.com/mymodule/v2/package1"`
+  * New import statement: `import "example.com/mymodule/v2/package2"`
 
 For publishing steps, see [Publishing a module](/doc/modules/publishing).


### PR DESCRIPTION
At least according to the image this should be renamed. Not sure why the package directory is renamed in the image above.