### PR TITLE
Update web-service-gin to newer way of adding modules

### DIFF
--- a/_content/doc/tutorial/web-service-gin.md
+++ b/_content/doc/tutorial/web-service-gin.md
@@ -275,6 +275,13 @@ adding dependencies first, then the code that depends on them.
 
     Go resolved and downloaded this dependency to satisfy the `import`
     declaration you added in the previous step.
+    
+    If you receive errors when issuing `go get .` you may be using a newer version of Go. In this case, use `go mod tidy` to add the `github.com/gin-gonic/gin`
+    module.
+    
+    ```
+    go mod tidy
+    ```
 
 2. From the command line in the directory containing main.go, run the code.
     Use a dot argument to mean "run code in the current directory."


### PR DESCRIPTION
Hi, I was following this tutorial using Go 1.17 and saw that using `go get .` doesn't work to install the github.com/gin-gonic/gin module. I followed this stack overflow: https://stackoverflow.com/questions/69025385/go-1-14-to-1-17-update-modules-not-working-anymore and found that `go mod tidy` correctly added the module for me. Obviously open to wording, refactoring, reconsideration changes