### PR TITLE
Fix doc url in _content/learn/quickstart.yaml

### DIFF
--- a/_content/learn/quickstart.yaml
+++ b/_content/learn/quickstart.yaml
@@ -2,7 +2,7 @@
     content: Everything there is to know about Go. Get started on a new project
       or brush up for your existing Go code.
     cta: View documentation
-    url: /doc/install
+    url: /doc/
   - title: Tour of Go
     content: An interactive introduction to Go in three sections. Each section
       concludes with a few exercises so you can practice what you've learned.


### PR DESCRIPTION
Fixes issue mentioned https://github.com/golang/go/issues/49971