### PR TITLE
Use var name consistently

### DIFF
--- a/_content/doc/tutorial/add-a-test.html
+++ b/_content/doc/tutorial/add-a-test.html
@@ -46,9 +46,9 @@ import (
 func TestHelloName(t *testing.T) {
     name := "Gladys"
     want := regexp.MustCompile(`\b`+name+`\b`)
-    msg, err := Hello("Gladys")
+    msg, err := Hello(name)
     if !want.MatchString(msg) || err != nil {
-        t.Fatalf(`Hello("Gladys") = %q, %v, want match for %#q, nil`, msg, err, want)
+        t.Fatalf(`Hello("%v") = %q, %v, want match for %#q, nil`, name, msg, err, want)
     }
 }
 


### PR DESCRIPTION
The TestHelloName test declares and initializes the name variable as the
subject of the test. In the example, the variable is used only for the
definition of the regular expression. I suggest using the variable also as
the argument of the method to be tested and for the error message to be output.