### PR TITLE
Add missing changed line highlighting

### DIFF
--- a/_content/doc/tutorial/greetings-multiple-people.html
+++ b/_content/doc/tutorial/greetings-multiple-people.html
@@ -159,7 +159,7 @@ func main() {
     names := []string{"Gladys", "Samantha", "Darrin"}</ins>
 
     // Request greeting messages for the names.
-    messages, err := greetings.Hellos(names)
+    <ins>messages, err := greetings.Hellos(names)</ins>
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
At end of https://go.dev/doc/tutorial/random-greeting , we had `message, err := greetings.Hello("Gladys")`

This step of tutorial changes that line to `messages, err := greetings.Hellos(names)` but this line is not highlighted on the website right now