### PR TITLE
_content: fixed the play url in main and footer

### DIFF
--- a/_content/menus.yaml
+++ b/_content/menus.yaml
@@ -8,7 +8,7 @@ main:
   - name: Packages
     url: https://pkg.go.dev
   - name: Play
-    url: /play/
+    url: https://go.dev/play/
   - name: Blog
     url: /blog/
 
@@ -25,7 +25,7 @@ footer:
     url: /learn/
     children:
     - name: Playground
-      url: /play
+      url: https://go.dev/play/
     - name: Tour
       url: /tour/
     - name: Stack Overflow

--- a/_content/menus.yaml
+++ b/_content/menus.yaml
@@ -8,7 +8,7 @@ main:
   - name: Packages
     url: https://pkg.go.dev
   - name: Play
-    url: https://go.dev/play/
+    url: https://go.dev/play/?v=gotip
   - name: Blog
     url: /blog/
 
@@ -25,7 +25,7 @@ footer:
     url: /learn/
     children:
     - name: Playground
-      url: https://go.dev/play/
+      url: https://go.dev/play/?v=gotip
     - name: Tour
       url: /tour/
     - name: Stack Overflow


### PR DESCRIPTION
Play link of the menu and Playground link from the footer both redirects to tip.golang.org/play from tip.golang.org which do not exist.