### PR TITLE
_content/blog: fix concept errors

### DIFF
--- a/_content/blog/go1.md
+++ b/_content/blog/go1.md
@@ -29,7 +29,7 @@ in many environments, on a time scale of years.
 Similarly, authors who write books about Go 1 can be sure that their examples
 and explanations will be helpful to readers today and into the future.
 
-Forward compatibility is part of stability.
+Backward compatibility is part of stability.
 Code that compiles in Go 1 should, with few exceptions,
 continue to compile and run throughout the lifetime of that version,
 even as we issue updates and bug fixes such as Go version 1.1, 1.2, and so on.


### PR DESCRIPTION
Backward compatible refers to a hardware or software system that can successfully use interfaces and data from earlier versions of the system or with other systems.

Go 1.17 can compile and run the program writed by Go 1.11,but not vice versa.  So I think it might be a fallacy