### PR TITLE
Remove extraneous ordered list from fuzz tutorial

### DIFF
--- a/_content/doc/tutorial/fuzz.md
+++ b/_content/doc/tutorial/fuzz.md
@@ -316,18 +316,18 @@ Note the syntax differences between the unit test and the fuzz test:
   types to be fuzzed. The inputs from your unit test are provided as seed corpus
   inputs using `f.Add`.
 
-2. Ensure the new package, `unicode/utf8` has been imported.
+Ensure the new package, `unicode/utf8` has been imported.
 
-   ```
-   package main
+```
+package main
 
-   import (
-       "testing"
-       "unicode/utf8"
-   )
-   ```
+import (
+   "testing"
+   "unicode/utf8"
+)
+```
 
-   With the unit test converted to a fuzz test, it’s time to run the test again.
+With the unit test converted to a fuzz test, it’s time to run the test again.
 
 ### Run the code
 


### PR DESCRIPTION
Resolves https://github.com/golang/go/issues/51372.

An extraneous ordered list item was left in the doc. This change removes it and left-aligns it for consistency with the rest of the section.