### PR TITLE
_content/doc/tutorial: fix non highlighted text editions

### DIFF
--- a/_content/doc/tutorial/greetings-multiple-people.html
+++ b/_content/doc/tutorial/greetings-multiple-people.html
@@ -159,7 +159,7 @@ func main() {
     names := []string{"Gladys", "Samantha", "Darrin"}</ins>
 
     // Request greeting messages for the names.
-    messages, err := greetings.Hellos(names)
+    <ins>messages, err := greetings.Hellos(names)</ins>
     if err != nil {
         log.Fatal(err)
     }


### PR DESCRIPTION
Step 2 changes on file hello.go are not highlighted on https://go.dev/doc/tutorial/greetings-multiple-people.