### PR TITLE
_content/doc/tutorial: fix inaccuracies in workspace tutorial

### DIFF
--- a/_content/doc/tutorial/workspaces.md
+++ b/_content/doc/tutorial/workspaces.md
@@ -177,7 +177,7 @@ add a new function to the `stringutil` package that we can use instead of `Rever
 
    use (
        ./hello
-       example
+       ./example
    )
    ```
 

--- a/_content/doc/tutorial/workspaces.md
+++ b/_content/doc/tutorial/workspaces.md
@@ -177,7 +177,7 @@ add a new function to the `stringutil` package that we can use instead of `Rever
 
    use (
        ./hello
-       ./example
+       example
    )
    ```
 
@@ -230,7 +230,7 @@ add a new function to the `stringutil` package that we can use instead of `Rever
    From the workspace directory, run
 
    ```
-   $ go run example/hello
+   $ go run example.com/hello
    HELLO
    ```
 
@@ -256,7 +256,7 @@ add a new function to the `stringutil` package that we can use instead of `Rever
 
    ```
    cd hello
-   go get example.com/dep@v0.1.0
+   go get golang.org/x/example@v0.1.0
    ```
 
    That way, the `go` command can properly resolve the modules outside the workspace.


### PR DESCRIPTION
the first change is related to: https://github.com/golang/go/issues/51449