### PR TITLE
Remove the beta title

### DIFF
--- a/_content/doc/index.html
+++ b/_content/doc/index.html
@@ -49,12 +49,12 @@ Multi-module workspaces are useful for making changes across multiple modules.
 Introduces the basics of writing a RESTful web service API with Go and the Gin Web Framework.
 </p>
 
-<h3 id="generics-tutorial"><a href="/doc/tutorial/generics.html">Tutorial: Getting started with generics (beta)</a></h3>
+<h3 id="generics-tutorial"><a href="/doc/tutorial/generics.html">Tutorial: Getting started with generics</a></h3>
 <p>
 With generics, you can declare and use functions or types that are written to work with any of a set of types provided by calling code.
 </p>
 
-<h3 id="fuzz-tutorial"><a href="/doc/tutorial/fuzz.html">Tutorial: Getting started with fuzzing (beta)</a></h3>
+<h3 id="fuzz-tutorial"><a href="/doc/tutorial/fuzz.html">Tutorial: Getting started with fuzzing</a></h3>
 <p>
 Fuzzing can generate inputs to your tests that can catch edge cases and security issues that you may have missed.
 </p>


### PR DESCRIPTION
Go 1.18 has been released, but the document title is still beta, so beta needs to be removed.