### PR TITLE
_content/doc: add missing words on workspaces.md file

### DIFF
--- a/_content/doc/tutorial/workspaces.md
+++ b/_content/doc/tutorial/workspaces.md
@@ -230,7 +230,7 @@ add a new function to the `stringutil` package that we can use instead of `Rever
    From the workspace directory, run
 
    ```
-   $ go run example/hello
+   $ go run example.com/hello
    HELLO
    ```
 


### PR DESCRIPTION
This PR only add missing word when trying to run `go run example/hello`. Error GOROOT will be occurred. So adding `.com` will fix it.