### PR TITLE
chore: render video embeds at 16x9

### DIFF
--- a/_content/css/styles.css
+++ b/_content/css/styles.css
@@ -3696,6 +3696,19 @@ img.PullQuote-image {
   color: #999;
   font-size: smaller;
 }
+#blog #content .iframe {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+#blog #content .iframe iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
 #blog #content .iframe, #content .image {
   margin: 20px;
 }


### PR DESCRIPTION
### Description
- Video embeds are currently breaking their container on mobile and also look a bit odd on desktop due to the smaller size compared to the rest of the page

#### Before
![2022-03-25 16 33 29](https://user-images.githubusercontent.com/42720791/160197178-ef3ae787-c3d2-4417-ae81-4d41aea4333c.gif)

#### After
![2022-03-25 16 33 38](https://user-images.githubusercontent.com/42720791/160197494-946ef6ba-dd72-4eeb-9aba-a3840fd13c85.gif)


 