### PR TITLE
Fixed an issue: updated the text on workspace page 

### DIFF
--- a/_content/blog/get-familiar-with-workspaces.md
+++ b/_content/blog/get-familiar-with-workspaces.md
@@ -174,7 +174,7 @@ then add the new module to your workspace with `go work use [path-to-module].`
 
 ## Workspace commands
 
-Along with `go work init` and `go use`, Go 1.18 introduces the following
+Along with `go work init` and `go work use`, Go 1.18 introduces the following
 commands for workspaces:
 
 -  `go work sync`: pushes the dependencies in the `go.work` file back into

--- a/_content/blog/get-familiar-with-workspaces.md
+++ b/_content/blog/get-familiar-with-workspaces.md
@@ -9,7 +9,7 @@ tags:
 - go1.18
 summary: Learn about Go workspaces and some of the workflows they enable.
 ---
-
+ 
 Go 1.18 adds workspace mode to Go, which lets you work on multiple modules
 simultaneously.
 


### PR DESCRIPTION
x/website: error in the Go workspace blog #52252 

https://github.com/golang/go/issues/52252#issue-1198549147

I fixed this issue. changed a text on the website's get familiar with workspaces page.


<img width="1440" alt="Screen Shot 2022-04-11 at 4 29 51 AM" src="https://user-images.githubusercontent.com/44180677/162696634-dd543fce-6661-4bad-aa25-feb7e1ca46b6.png">

