### PR TITLE
_content: do not run playground code on page load

### DIFF
--- a/_content/js/playsite.js
+++ b/_content/js/playsite.js
@@ -23,7 +23,6 @@ window.addEventListener('load', () => {
 
     // The pre matched below is added by the code above. Style it appropriately.
     document.querySelector(".js-playgroundOutputEl pre").classList.add("Playground-output");
-    $('.js-playgroundRunEl').click();
 
     $('#code').linedtextarea();
     $('#code').attr('wrap', 'off');


### PR DESCRIPTION
The purpose is to avoid overwriting user content restored by opening recently
closed tab from the history.

It turns out that https://golang.org/cl/407055 does not address the issue
reliably. If the run action happens before the user content is restored, the
source code of the "hello world" example will be sent to the server for
formatting. Most of the time (if not always), the format result will return
after the user content is restored. In this case, the format result will
overwrite the restored user content.

We can delay the run action until the user content is restored. But it's
subtle to decide how long to delay. On the other hand, I think it does not
make sense to run the "hello world" example on load, so I prefer to address
the issue by removing the run action on page load.

Fixes golang/go#49895