### PR TITLE
internal/dl: mention architecture in two featured darwin files

### DIFF
--- a/internal/dl/dl.go
+++ b/internal/dl/dl.go
@@ -164,12 +164,12 @@ var featuredFiles = []Feature{
 		fileRE:       regexp.MustCompile(`\.windows-amd64\.msi$`),
 	},
 	{
-		Platform:     "Apple macOS",
+		Platform:     "Apple macOS (ARM64)",
 		Requirements: "macOS 11 or later, Apple 64-bit processor",
 		fileRE:       regexp.MustCompile(`\.darwin-arm64\.pkg$`),
 	},
 	{
-		Platform:     "Intel macOS",
+		Platform:     "Apple macOS (x86-64)",
 		Requirements: "macOS 10.13 or later, Intel 64-bit processor",
 		fileRE:       regexp.MustCompile(`\.darwin-amd64\.pkg$`),
 	},

--- a/internal/dl/dl.go
+++ b/internal/dl/dl.go
@@ -169,7 +169,7 @@ var featuredFiles = []Feature{
 		fileRE:       regexp.MustCompile(`\.darwin-arm64\.pkg$`),
 	},
 	{
-		Platform:     "Apple macOS",
+		Platform:     "Intel macOS",
 		Requirements: "macOS 10.13 or later, Intel 64-bit processor",
 		fileRE:       regexp.MustCompile(`\.darwin-amd64\.pkg$`),
 	},


### PR DESCRIPTION
There are two similar looking "Apple macOS" installers featured on the
download page. They differ only in the filename and in requirements.
Add the architecture name next to platform description to make them
easier to tell apart.