### PR TITLE
_content/blog/when-generics.md: fix typo in code

### DIFF
--- a/_content/blog/when-generics.md
+++ b/_content/blog/when-generics.md
@@ -235,7 +235,7 @@ function:
 {{raw `
 	// SortFn sorts s in place using a comparison function.
 	func SortFn[T any](s []T, less func(T, T) bool) {
-		sort.Sort(SliceFn[T]{s, cmp})
+		sort.Sort(SliceFn[T]{s, less})
 	}
 `}}
 


### PR DESCRIPTION
Thank you for great article!
 I found a small typo on example code. So, I fixed it!
`cmp` → `less`