### PR TITLE
doc: fix typo in comment.md

### DIFF
--- a/_content/doc/comment.md
+++ b/_content/doc/comment.md
@@ -573,7 +573,7 @@ For example:
 	// “[JSON and Go].”
 	//
 	// [RFC 7159]: https://tools.ietf.org/html/rfc7159
-	// [JSON and Go]: https://golang.org/doc/articles/json_and_go.htmlpackage json
+	// [JSON and Go]: https://golang.org/doc/articles/json_and_go.html
 	package json
 
 By keeping URLs in a separate section,


### PR DESCRIPTION
Removed duplicated "package json" string.