### PR TITLE
x/website: add loong instruction set desc

### DIFF
--- a/_content/doc/install/source.html
+++ b/_content/doc/install/source.html
@@ -53,6 +53,12 @@ The Go compilers support the following instruction sets:
   The <code>ARM</code> instruction set, 64-bit (<code>AArch64</code>) and 32-bit.
 </dd>
 <dt>
+  <code>loong64</code>
+</dt>
+<dd>
+  The LoongArch instruction set.
+</dd>
+<dt>
   <code>mips64</code>, <code>mips64le</code>, <code>mips</code>,  <code>mipsle</code>
 </dt>
 <dd>
@@ -597,6 +603,9 @@ The valid combinations of <code>$GOOS</code> and <code>$GOARCH</code> are:
 </tr>
 <tr>
 <td></td><td><code>linux</code></td> <td><code>arm64</code></td>
+</tr>
+<tr>
+<td></td><td><code>linux</code></td> <td><code>loong64</code></td>
 </tr>
 <tr>
 <td></td><td><code>linux</code></td> <td><code>ppc64</code></td>


### PR DESCRIPTION
Fixes [#54350](https://github.com/golang/go/issues/54350)
