### PR TITLE
tour: add information about the type alias `any`

### DIFF
--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -210,6 +210,8 @@ An empty interface may hold values of any type.
 Empty interfaces are used by code that handles values of unknown type.
 For example, `fmt.Print` takes any number of arguments of type `interface{}`.
 
+The `any` type is an alias for `interface{}` and is equivalent to `interface{}` in all ways. 
+
 .play methods/empty-interface.go
 
 * Type assertions


### PR DESCRIPTION
The page in the Go tour about the empty interface doesn't currently give any information about the type alias `any`, so this commit adds a short statement about the existence of this type.