### PR TITLE
_content: fix ineffective font colors

### DIFF
--- a/_content/lib/godoc/analysis/help.html
+++ b/_content/lib/godoc/analysis/help.html
@@ -108,7 +108,7 @@
   code with <b>callers</b> and <b>callees</b> information: callers
   information is associated with the <code>func</code> keyword that
   declares a function, and callees information is associated with the
-  open paren '<span style="color: dark-blue"><code>(</code></span>' of
+  open paren '<span style="color: darkblue"><code>(</code></span>' of
   a function call.
 </p>
 <p>


### PR DESCRIPTION
This string expected the font color to be dark blue, but it didn't take effect.