### PR TITLE
_content/doc: fix parseVersionNumber to handle versions without patch

### DIFF
--- a/_content/doc/download.js
+++ b/_content/doc/download.js
@@ -131,8 +131,8 @@ class DownloadsController {
 
   // get version number.
   parseVersionNumber(string) {
-    const rx = /(\d+\.)(\d+\.)(\d+)/g;
-    const matches = rx.exec(string)
+    const rx = /(\d+\.)(\d+)(\.\d+)?/g;
+    const matches = rx.exec(string);
     if (matches?.[0]) {
       return matches[0];
     } else {


### PR DESCRIPTION
As of go1.20, when visiting https://go.dev/doc/install, the download button shows no version and with text: `Download ()`.

Previously the function expected the argument `string` being passed as in the form: `go1.17.3.linux-amd64.tar.gz`.
with go1.20 the file name becomes `go1.20.linux-amd64.tar.gz` with no patch number.

This merge request fix the regex used to parse the version number and return the intended version of `1.20`