### PR TITLE
tour: no deterministic note as 1.20 does rand seed

### DIFF
--- a/_content/tour/basics.article
+++ b/_content/tour/basics.article
@@ -14,13 +14,6 @@ This program is using the packages with import paths `"fmt"` and `"math/rand"`.
 
 By convention, the package name is the same as the last element of the import path. For instance, the `"math/rand"` package comprises files that begin with the statement `package`rand`.
 
-#appengine: *Note:* The environment in which these programs are executed is
-#appengine: deterministic, so each time you run the example program
-#appengine: `rand.Intn` will return the same number.
-#appengine:
-#appengine: (To see a different number, seed the number generator; see [[/pkg/math/rand/#Seed][`rand.Seed`]].
-#appengine: Time is constant in the playground, so you will need to use something else as the seed.)
-
 .play basics/packages.go
 
 * Imports


### PR DESCRIPTION
With go 1.20 "math/rand package now automatically seeds the global random number generator" (https://go.dev/doc/go1.20#math/rand) and we do not need the appengine specific note that the Go Playground environment for the tour programs is deterministic.

As the note is specific to the appengine version (i.e. it is already not shown in the Go offline tour) it should be fine to just remove the text.

Fixes golang/tour#1448