### PR TITLE
tour: Map literals less changes and text details

### DIFF
--- a/_content/tour/moretypes.article
+++ b/_content/tour/moretypes.article
@@ -290,6 +290,16 @@ Map literals are like struct literals, but the keys are required.
 
 If the top-level type is just a type name, you can omit it from the elements of the literal.
 
+This map literal:
+
+	var m = map[string]Vertex{"Origin": Vertex{0, 0}}
+
+is the same as below with the type of the value understood from the map's element type:
+
+	var m = map[string]Vertex{"Origin": {0, 0}}
+
+This map contains elements of type `Vertex`, so each element literal may omit the known type name `Vertex`.
+
 .play moretypes/map-literals-continued.go
 
 * Mutating Maps

--- a/_content/tour/moretypes/map-literals.go
+++ b/_content/tour/moretypes/map-literals.go
@@ -9,12 +9,8 @@ type Vertex struct {
 }
 
 var m = map[string]Vertex{
-	"Bell Labs": Vertex{
-		40.68433, -74.39967,
-	},
-	"Google": Vertex{
-		37.42202, -122.08408,
-	},
+	"Bell Labs": Vertex{40.68433, -74.39967},
+	"Google":    Vertex{37.42202, -122.08408},
 }
 
 func main() {


### PR DESCRIPTION
Between 'map-literals.go' and 'map-literals-continued.go' there are four changes (omit element type, single line the block, add space to align the "Google" element, and remove the terminal comma in the block) which makes it hard for a reader to understand what it is "you can omit" in the 'Map literals continued' section of 'moretypes.article'.

To avoid the three text changes that the article does not talk about, update the before code in 'map-literals.go' to already be formatted on a single line per map entry.

Add code examples in the article explaining the two versions and why the literal element type may be elided.

Fixes golang/tour#1449