### PR TITLE
tour: Reader has method not func

### DIFF
--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -345,10 +345,6 @@ which represents the read end of a stream of data.
 
 The Go standard library contains [[https://cs.opensource.google/search?q=Read%5C(%5Cw%2B%5Cs%5C%5B%5C%5Dbyte%5C)&ss=go%2Fgo][many implementations]] of this interface, including files, network connections, compressors, ciphers, and others.
 
-The `io.Reader` interface has a `Read` method:
-
-	func (T) Read(b []byte) (n int, err error)
-
 `Read` populates the given byte slice with data and returns the number of bytes
 populated and an error value. It returns an `io.EOF` error when the stream
 ends.

--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -343,6 +343,10 @@ Change your `Sqrt` function to return an `ErrNegativeSqrt` value when given a ne
 The `io` package specifies the `io.Reader` interface,
 which represents the read end of a stream of data.
 
+	type Reader interface {
+		Read(p []byte) (n int, err error)
+	}
+
 The Go standard library contains [[https://cs.opensource.google/search?q=Read%5C(%5Cw%2B%5Cs%5C%5B%5C%5Dbyte%5C)&ss=go%2Fgo][many implementations]] of this interface, including files, network connections, compressors, ciphers, and others.
 
 `Read` populates the given byte slice with data and returns the number of bytes


### PR DESCRIPTION
Interfaces do not define func as in the current text of "Readers"
("/tour/methods/21"). The interface specifies a list of methods, just Read() in
this case. It is confusing to say "interface has a Read method" and then show a
code line defining what would be a method on a type that impliments the
interface.

Changed the article text to follow the pattern of "Stringers"
("/tour/methods/17") which shows the interface definition in the code block. In
following this pattern I moved the code just below that text about the package
io and its io.Reader interface.

Fixes golang/tour#1450

Change is in two commits to try to avoid stomping on the blame log for the line between "The Go standard library contains...".  Not sure this was successful, useful, or needed.