### PR TITLE
tour: added missing word "methods"

### DIFF
--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -131,7 +131,7 @@ The first is so that the method can modify the value that its receiver points to
 The second is to avoid copying the value on each method call.
 This can be more efficient if the receiver is a large struct, for example.
 
-In this example, both `Scale` and `Abs` are with receiver type `*Vertex`,
+In this example, both `Scale` and `Abs` are methods with receiver type `*Vertex`,
 even though the `Abs` method needn't modify its receiver.
 
 In general, all methods on a given type should have either value or pointer


### PR DESCRIPTION
Missing word "methods" in fourth paragraph of screen "Choosing a value or pointer receiver".  Reads more clearly when what is being talked about is identified.

Fixes golang/tour#1352