### PR TITLE
tour: less confusing example in basics/7

### DIFF
--- a/_content/tour/basics/named-results.go
+++ b/_content/tour/basics/named-results.go
@@ -4,9 +4,11 @@ package main
 
 import "fmt"
 
-func split(sum int) (x, y int) {
-	x = sum * 4 / 9
-	y = sum - x
+func split(number int) (ones_digit, high_digits int) {
+	// both named return values are already defined as int variables
+	ones_digit = number % 10
+	high_digits = number - ones_digit
+	// will use named return values (ones_digit, high_digits)
 	return
 }
 


### PR DESCRIPTION
The code example in basics/7 (named-results.go) is confusing on many levels. The return values are not descriptive, thus offer no understanding of what function does.  The paramater name (sum) seems to imply some prerequisite sum of values that is not defined nor explained anywhere.  The math for 17 * 4 / 9 = 7 because of int truncation is confusing to some and not relavant to what the slide is trying to explain.

Provide descriptive names for parameters that match expected input (a number) and return value names that should be helpful in understanding what the function does.  Change the function body to return the same values for the example input as the old code, but hopefully be a more understandable process.

Add a couple comments to directly explain that the named return values are already defined at the top of the function as well as what will be returned by the naked return.

Fixes golang/tour#730
Fixes golang/tour#840
Fixes golang/tour#777
Fixes golang/tour#489