### PR TITLE
tour: mention generic functions in generics/1

### DIFF
--- a/_content/tour/generics.article
+++ b/_content/tour/generics.article
@@ -6,7 +6,8 @@ https://golang.org
 
 * Type parameters
 
-Go functions can be written to work on multiple types using type parameters. The
+Go functions can be written to work on multiple types using type parameters,
+known as a _generic_function_.  The
 type parameters of a function appear between brackets, before the function's
 arguments.
 


### PR DESCRIPTION
The first slide of generics (about generic functions) never uses the phrase "generic function". Adding to the confusion, the next slide (generics/2) then says "In addition to generic functions..." as if the reader should know about them.

Added the name "generic function" to generics/1 to explain that adding type parameters to a func make a generic function.