### PR TITLE
tour: let reader know Walk should send in order

### DIFF
--- a/_content/tour/concurrency.article
+++ b/_content/tour/concurrency.article
@@ -113,7 +113,7 @@ Continue description on [[javascript:click('.next-page')][next page]].
 
 * Exercise: Equivalent Binary Trees
 
-*1.* Implement the `Walk` function.
+*1.* Implement the `Walk` function to send all `t` values to `ch` in order.
 
 *2.* Test the `Walk` function.
 

--- a/_content/tour/concurrency/exercise-equivalent-binary-trees.go
+++ b/_content/tour/concurrency/exercise-equivalent-binary-trees.go
@@ -4,8 +4,8 @@ package main
 
 import "golang.org/x/tour/tree"
 
-// Walk walks the tree t sending all values
-// from the tree to the channel ch.
+// Walk walks the sorted tree t sending all values
+// in order from the tree to the channel ch.
 func Walk(t *tree.Tree, ch chan int)
 
 // Same determines whether the trees

--- a/_content/tour/solutions/binarytrees.go
+++ b/_content/tour/solutions/binarytrees.go
@@ -21,8 +21,8 @@ func walkImpl(t *tree.Tree, ch chan int) {
 	walkImpl(t.Right, ch)
 }
 
-// Walk walks the tree t sending all values
-// from the tree to the channel ch.
+// Walk walks the sorted tree t sending all values
+// in order from the tree to the channel ch.
 func Walk(t *tree.Tree, ch chan int) {
 	walkImpl(t, ch)
 	// Need to close the channel here

--- a/_content/tour/solutions/binarytrees_quit.go
+++ b/_content/tour/solutions/binarytrees_quit.go
@@ -26,8 +26,8 @@ func walkImpl(t *tree.Tree, ch, quit chan int) {
 	walkImpl(t.Right, ch, quit)
 }
 
-// Walk walks the tree t sending all values
-// from the tree to the channel ch.
+// Walk walks the sorted tree t sending all values
+// in order from the tree to the channel ch.
 func Walk(t *tree.Tree, ch, quit chan int) {
 	walkImpl(t, ch, quit)
 	close(ch)


### PR DESCRIPTION
In "Exercise: Equivalent Binary Trees" neither the slide text nor the code state Walk() should send the values in order. Doing so in order makes using the output much more useful in Same(), but might not be easy to see for readers that have not had a data structures class. In order traversal is implied by reference with the binary tree being "always sorted" and the output defined as "should be the numbers 1, 2, 3, ..., 10."

Update the slide text to say what Walk() does. Change Walk() comments in code/solution to match.

Fixes golang/tour#158