### PR TITLE
tour: character removed in deference to rune

### DIFF
--- a/_content/tour/basics.article
+++ b/_content/tour/basics.article
@@ -203,7 +203,7 @@ Try changing the initial value of `v` in the example code and observe how its ty
 
 Constants are declared like variables, but with the `const` keyword.
 
-Constants can be character, string, boolean, or numeric values.
+Constants can be string, boolean, or numeric values.
 
 Constants cannot be declared using the `:=` syntax.
 


### PR DESCRIPTION
In tour/basics/15 ("Constants") the word "character" is both new (not used in the tour before this slide) and confusing as it is not the Go way to talk about runes. Since "numeric values" is called out a few words later (which includes rune constants), neither rune nor character is needed here.

Remove odd word "character" to avoid confusing readers with unneeded non-Go terminology.

Fixes golang/tour#497
Fixes golang/tour#1151