### PR TITLE
tour: more examples of literal const values

### DIFF
--- a/_content/tour/basics/constants.go
+++ b/_content/tour/basics/constants.go
@@ -4,7 +4,12 @@ package main
 
 import "fmt"
 
-const Pi = 3.14
+const Warm = "to 175°C" // string constant
+const Pie = false       // boolean constant
+const Hash = '#'        // rune constant
+const One = 1           // integer constant
+const Pi = 3.14         // floating-point constant
+const Other = 6.7i      // imaginary constant
 
 func main() {
 	const World = "世界"


### PR DESCRIPTION
In tour/basics/15 ("Constants") the slide talks of "string, boolean, or numeric values", but the code only has examples of float and boolean.

Add examples of constants from string, boolean, and other numeric (rune, integer, & imaginary) literals in the same order as the slide text.