### PR TITLE
tour: struct literals in same def/print order

### DIFF
--- a/_content/tour/moretypes/struct-literals.go
+++ b/_content/tour/moretypes/struct-literals.go
@@ -12,9 +12,9 @@ var (
 	v1 = Vertex{1, 2}  // has type Vertex
 	v2 = Vertex{X: 1}  // Y:0 is implicit
 	v3 = Vertex{}      // X:0 and Y:0
-	p  = &Vertex{1, 2} // has type *Vertex
+	p  = &Vertex{3, 4} // has type *Vertex
 )
 
 func main() {
-	fmt.Println(v1, p, v2, v3)
+	fmt.Println(v1, v2, v3, p)
 }


### PR DESCRIPTION
The current code on "tour/moretypes/5" ("Struct Literals") seems to be designed to confuse a reader into thinking that contents of 'v1' and 'p' are importantly the same.  The contents of both variable's structs have the same int values and then when printed they are (what seems like purposefully, but with no explanation) printed next to each other.

Set the values in 'p' to be different and print the values in the same order they are defined in.