### PR TITLE
tour: playground is always on a Tuesday

### DIFF
--- a/_content/tour/flowcontrol.article
+++ b/_content/tour/flowcontrol.article
@@ -137,7 +137,7 @@ Switch cases evaluate cases from top to bottom, stopping when a case succeeds.
 
 does not call `f` if `i==0`.)
 
-#appengine: *Note:* Time in the Go playground always appears to start at
+#appengine: *Note:* Time in the Go playground always appears to start on a Tuesday at
 #appengine: 2009-11-10 23:00:00 UTC, a value whose significance is left as an
 #appengine: exercise for the reader.
 


### PR DESCRIPTION
In "tour/flowcontrol/10" ("Switch evaluation order") the interaction between the code using "Now()" and the Go Playground starting on 2009-11-10 is less than obvious.  The data the reader needs is that it starts on a Tuesday.

Add the day of week to the online Go Playground note for readers to be able to understand the output.

Fixes golang/tour#1407
Fixes golang/tour#1339
Fixes golang/tour#1249
Fixes golang/tour#1068