### PR TITLE
tour: type switch compares types

### DIFF
--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -243,7 +243,7 @@ Note the similarity between this syntax and that of reading from a map.
 A _type_switch_ is a construct that permits several type assertions in series.
 
 A type switch is like a regular switch statement, but the cases in a type
-switch specify types (not values), and those values are compared against
+switch specify types (not values), and those types are compared against
 the type of the value held by the given interface value.
 
 	switch v := i.(type) {


### PR DESCRIPTION
In "methods/16" ("Type switches") the current slide explicitly says "a type switch specify types (not values)" and then talks about "those values" which should be "types". Quoting the spec "A type switch compares types rather than values."

Replaced "values" with "types" where the slide is talking about types.

Fixes golang/tour#1461