### PR TITLE
tour: point out using a non-struct package type

### DIFF
--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -35,7 +35,9 @@ In this example we see a numeric type `MyFloat` with an `Abs` method.
 You can only declare a method with a receiver whose type is defined in the same
 package as the method.
 You cannot declare a method with a receiver whose type is defined in another
-package (which includes the built-in types such as `int`).
+package (which includes the built-in types such as `int` or `float64`).
+Notice that the type of var `f` has been converted to type `MyFloat` so that
+the `Abs` method can be called with receiver `f`.
 
 .play methods/methods-continued.go
 


### PR DESCRIPTION
In "tour/methods/3" ("Methods continued") we have the first use of a package local type that is not a struct and not an interface.  Thus the code setting variable "f" is somewhat novel and should be highlighted. The slide text also talks about not being able to define methods on "built-in types such as int" which is less interesting as the type wrapped in the example code is "float64".

Point out that that "float64" is among the built-in types to mirror the usage in the code ("methods-continued.go"). Explicitly call attention to the creation of a MyFloat variable for use with a method.

Does some backfill for confusion in golang/tour#191