### PR TITLE
tour: clear up source/destination slice confusion

### DIFF
--- a/_content/tour/moretypes.article
+++ b/_content/tour/moretypes.article
@@ -138,9 +138,9 @@ then builds a slice that references it:
 
 When slicing, you may omit the high or low bounds to use their defaults instead.
 
-The default is zero for the low bound and the length of the slice for the high bound.
+The default is zero for the low bound and the length of the sliced operand for the high bound.
 
-For the array
+Given a slice operand of this array
 
 	var a [10]int
 
@@ -150,6 +150,8 @@ these slice expressions are equivalent:
 	a[:10]
 	a[0:]
 	a[:]
+
+In the program to the right the slice operands are themselves also slices.
 
 .play moretypes/slice-bounds.go
 


### PR DESCRIPTION
In "tour/moretypes/10" ("Slice defaults") the phrase "the length of the slice for the high bound" has generated more than a dozen issues, mostly wanting to replace "slice" with "array". The confusion is that when slicing, the word "slice" is not well defined we will have an output slice (result of the slice expression) and may well have a input slice (e.g. in the example code in "slice-bounds.go"). The spec uses the phrase "length of the sliced operand" for the high bound.

Change wording of slice default upper bound to phrase used in "ref/spec" and reword the slide text to point out what the "sliced operands" are in the slide and program examples.

Fixes golang/tour#1386
Fixes golang/tour#879
Fixes golang/tour#855
Fixes golang/tour#821
Fixes golang/tour#679
Fixes golang/tour#448
Fixes golang/tour#182

See golang/tour#182 for context and links to many of the issues.