### PR TITLE
tour: fix typo in slice defaults description

### DIFF
--- a/_content/tour/moretypes.article
+++ b/_content/tour/moretypes.article
@@ -138,7 +138,7 @@ then builds a slice that references it:
 
 When slicing, you may omit the high or low bounds to use their defaults instead.
 
-The default is zero for the low bound and the length of the slice for the high bound.
+The default is zero for the low bound and the length of the array for the high bound.
 
 For the array
 


### PR DESCRIPTION
Correctly indicate that default higher bound of slice is length of the underlying *array*