### PR TITLE
tour: update links to go.dev

### DIFF
--- a/_content/tour/basics.article
+++ b/_content/tour/basics.article
@@ -2,7 +2,7 @@ Packages, variables, and functions.
 Learn the basic components of any Go program.
 
 The Go Authors
-https://golang.org
+https://go.dev
 
 * Packages
 
@@ -54,7 +54,7 @@ In this example, `add` takes two parameters of type `int`.
 
 Notice that the type comes _after_ the variable name.
 
-(For more about why types look the way they do, see the [[https://blog.golang.org/gos-declaration-syntax][article on Go's declaration syntax]].)
+(For more about why types look the way they do, see the [[https://go.dev/blog/declaration-syntax][article on Go's declaration syntax]].)
 
 .play basics/functions.go
 

--- a/_content/tour/concurrency.article
+++ b/_content/tour/concurrency.article
@@ -2,7 +2,7 @@ Concurrency
 Go provides concurrency constructions as part of the core language. This lesson presents them and gives some examples on how they can be used.
 
 The Go Authors
-https://golang.org
+https://go.dev
 
 * Goroutines
 

--- a/_content/tour/flowcontrol.article
+++ b/_content/tour/flowcontrol.article
@@ -2,7 +2,7 @@ Flow control statements: for, if, else, switch and defer
 Learn how to control the flow of your code with conditionals, loops, switches and defers.
 
 The Go Authors
-https://golang.org
+https://go.dev
 
 * For
 

--- a/_content/tour/generics.article
+++ b/_content/tour/generics.article
@@ -2,7 +2,7 @@ Generics
 Go supports generic programming using type parameters. This lesson shows some examples for employing generics in your code.
 
 The Go Authors
-https://golang.org
+https://go.dev
 
 * Type parameters
 

--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -2,7 +2,7 @@ Methods and interfaces
 This lesson covers methods and interfaces, the constructs that define objects and their behavior.
 
 The Go Authors
-https://golang.org
+https://go.dev
 
 * Methods
 

--- a/_content/tour/moretypes.article
+++ b/_content/tour/moretypes.article
@@ -2,7 +2,7 @@ More types: structs, slices, and maps.
 Learn how to define types based on existing ones: this lesson covers structs, arrays, slices, and maps.
 
 The Go Authors
-https://golang.org
+https://go.dev
 
 * Pointers
 

--- a/_content/tour/welcome.article
+++ b/_content/tour/welcome.article
@@ -2,7 +2,7 @@ Welcome!
 Learn how to use this tour: including how to navigate the different lessons and how to run code.
 
 The Go Authors
-https://golang.org
+https://go.dev
 
 * Hello, 世界
 
@@ -79,8 +79,8 @@ Click the [[javascript:highlightAndClick(".next-page")]["next"]] button or type 
 
 #appengine: * The Go Playground
 #appengine:
-#appengine: This tour is built atop the [[https://play.golang.org/][Go Playground]], a
-#appengine: web service that runs on [[/][golang.org]]'s servers.
+#appengine: This tour is built atop the [[/play/][Go Playground]], a
+#appengine: web service that runs on [[/][go.dev]]'s servers.
 #appengine:
 #appengine: The service receives a Go program, compiles, links, and runs the program inside
 #appengine: a sandbox, then returns the output.


### PR DESCRIPTION
There are a few links in the tour (and tour source) that point at golang.org rather than go.dev in places that are redirected to go.dev. Seems reasonable to update these links as the public face for all of these is go.dev now.

Some of these are in the headers of the *.article files, so I don't think they show up anywhere on the web site, changed for consistency. One was a blog link, just used what the web servers sent as the redirect. Last pair were updating the links about the Go Playground, as they are both behind "#appengine:" it is safe to assume access on go.dev and use origin-relative links (e.g. /play/)

Update links to go.dev versions in tour article files.

Fixes golang/tour#1394