### PR TITLE
tour: absolute links so they work in offline tour

### DIFF
--- a/_content/tour/concurrency.article
+++ b/_content/tour/concurrency.article
@@ -16,7 +16,7 @@ starts a new goroutine running
 
 The evaluation of `f`, `x`, `y`, and `z` happens in the current goroutine and the execution of `f` happens in the new goroutine.
 
-Goroutines run in the same address space, so access to shared memory must be synchronized. The [[/pkg/sync/][`sync`]] package provides useful primitives, although you won't need them much in Go as there are other primitives. (See the next slide.)
+Goroutines run in the same address space, so access to shared memory must be synchronized. The [[https://go.dev/pkg/sync/][`sync`]] package provides useful primitives, although you won't need them much in Go as there are other primitives. (See the next slide.)
 
 .play concurrency/goroutines.go
 
@@ -145,7 +145,7 @@ one goroutine can access a variable at a time to avoid conflicts?
 This concept is called _mutual_exclusion_, and the conventional name for the data structure that provides it is _mutex_.
 
 Go's standard library provides mutual exclusion with
-[[/pkg/sync/#Mutex][`sync.Mutex`]] and its two methods:
+[[https://go.dev/pkg/sync/#Mutex][`sync.Mutex`]] and its two methods:
 
 - `Lock`
 - `Unlock`
@@ -171,38 +171,38 @@ safe for concurrent use!
 * Where to Go from here...
 
 #appengine: You can get started by
-#appengine: [[/doc/install/][installing Go]].
+#appengine: [[https://go.dev/doc/install/][installing Go]].
 
 #appengine: Once you have Go installed, the
 The
-[[/doc/][Go Documentation]] is a great place to
+[[https://go.dev/doc/][Go Documentation]] is a great place to
 #appengine: continue.
 start.
 It contains references, tutorials, videos, and more.
 
-To learn how to organize and work with Go code, read [[/doc/code][How to Write Go Code]].
+To learn how to organize and work with Go code, read [[https://go.dev/doc/code][How to Write Go Code]].
 
-If you need help with the standard library, see the [[/pkg/][package reference]]. For help with the language itself, you might be surprised to find the [[/ref/spec][Language Spec]] is quite readable.
+If you need help with the standard library, see the [[https://go.dev/pkg/][package reference]]. For help with the language itself, you might be surprised to find the [[https://go.dev/ref/spec][Language Spec]] is quite readable.
 
 To further explore Go's concurrency model, watch
 [[https://www.youtube.com/watch?v=f6kdp27TYZs][Go Concurrency Patterns]]
-([[/talks/2012/concurrency.slide][slides]])
+([[https://go.dev/talks/2012/concurrency.slide][slides]])
 and
 [[https://www.youtube.com/watch?v=QDDwwePbDtw][Advanced Go Concurrency Patterns]]
-([[/talks/2013/advconc.slide][slides]])
+([[https://go.dev/talks/2013/advconc.slide][slides]])
 and read the
-[[/doc/codewalk/sharemem/][Share Memory by Communicating]]
+[[https://go.dev/doc/codewalk/sharemem/][Share Memory by Communicating]]
 codewalk.
 
 To get started writing web applications, watch
 [[https://vimeo.com/53221558][A simple programming environment]]
-([[/talks/2012/simple.slide][slides]])
+([[https://go.dev/talks/2012/simple.slide][slides]])
 and read the
-[[/doc/articles/wiki/][Writing Web Applications]] tutorial.
+[[https://go.dev/doc/articles/wiki/][Writing Web Applications]] tutorial.
 
-The [[/doc/codewalk/functions/][First Class Functions in Go]] codewalk gives an interesting perspective on Go's function types.
+The [[https://go.dev/doc/codewalk/functions/][First Class Functions in Go]] codewalk gives an interesting perspective on Go's function types.
 
-The [[/blog/][Go Blog]] has a large archive of informative Go articles.
+The [[https://go.dev/blog/][Go Blog]] has a large archive of informative Go articles.
 
-Visit [[/][the Go home page]] for more.
+Visit [[https://go.dev/][the Go home page]] for more.
 

--- a/_content/tour/flowcontrol.article
+++ b/_content/tour/flowcontrol.article
@@ -100,7 +100,7 @@ Next, change the loop condition to stop once the value has stopped
 changing (or only changes by a very small amount).
 See if that's more or fewer than 10 iterations.
 Try other initial guesses for z, like x, or x/2.
-How close are your function's results to the [[/pkg/math/#Sqrt][math.Sqrt]] in the standard library?
+How close are your function's results to the [[https://go.dev/pkg/math/#Sqrt][math.Sqrt]] in the standard library?
 
 (*Note:* If you are interested in the details of the algorithm, the z² − x above
 is how far away z² is from where it needs to be (x), and the division by 2z is the derivative
@@ -167,7 +167,7 @@ Deferred function calls are pushed onto a stack. When a function returns, its
 deferred calls are executed in last-in-first-out order.
 
 To learn more about defer statements read this
-[[/blog/defer-panic-and-recover][blog post]].
+[[https://go.dev/blog/defer-panic-and-recover][blog post]].
 
 .play flowcontrol/defer-multi.go
 

--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -269,7 +269,7 @@ of the same interface type and value as `i`.
 
 * Stringers
 
-One of the most ubiquitous interfaces is [[/pkg/fmt/#Stringer][`Stringer`]] defined by the [[/pkg/fmt/][`fmt`]] package.
+One of the most ubiquitous interfaces is [[https://go.dev/pkg/fmt/#Stringer][`Stringer`]] defined by the [[https://go.dev/pkg/fmt/][`fmt`]] package.
 
 	type Stringer interface {
 		String() string
@@ -354,7 +354,7 @@ populated and an error value. It returns an `io.EOF` error when the stream
 ends.
 
 The example code creates a
-[[/pkg/strings/#Reader][`strings.Reader`]]
+[[https://go.dev/pkg/strings/#Reader][`strings.Reader`]]
 and consumes its output 8 bytes at a time.
 
 .play methods/reader.go
@@ -368,9 +368,9 @@ Implement a `Reader` type that emits an infinite stream of the ASCII character
 
 * Exercise: rot13Reader
 
-A common pattern is an [[/pkg/io/#Reader][io.Reader]] that wraps another `io.Reader`, modifying the stream in some way.
+A common pattern is an [[https://go.dev/pkg/io/#Reader][io.Reader]] that wraps another `io.Reader`, modifying the stream in some way.
 
-For example, the [[/pkg/compress/gzip/#NewReader][gzip.NewReader]] function takes an `io.Reader` (a stream of compressed data) and returns a `*gzip.Reader` that also implements `io.Reader` (a stream of the decompressed data).
+For example, the [[https://go.dev/pkg/compress/gzip/#NewReader][gzip.NewReader]] function takes an `io.Reader` (a stream of compressed data) and returns a `*gzip.Reader` that also implements `io.Reader` (a stream of the decompressed data).
 
 Implement a `rot13Reader` that implements `io.Reader` and reads from an `io.Reader`, modifying the stream by applying the [[https://en.wikipedia.org/wiki/ROT13][rot13]] substitution cipher to all alphabetical characters.
 
@@ -381,7 +381,7 @@ Make it an `io.Reader` by implementing its `Read` method.
 
 * Images
 
-[[/pkg/image/#Image][Package image]] defines the `Image` interface:
+[[https://go.dev/pkg/image/#Image][Package image]] defines the `Image` interface:
 
 	package image
 
@@ -392,12 +392,12 @@ Make it an `io.Reader` by implementing its `Read` method.
 	}
 
 *Note*: the `Rectangle` return value of the `Bounds` method is actually an
-[[/pkg/image/#Rectangle][`image.Rectangle`]], as the
+[[https://go.dev/pkg/image/#Rectangle][`image.Rectangle`]], as the
 declaration is inside package `image`.
 
-(See [[/pkg/image/#Image][the documentation]] for all the details.)
+(See [[https://go.dev/pkg/image/#Image][the documentation]] for all the details.)
 
-The `color.Color` and `color.Model` types are also interfaces, but we'll ignore that by using the predefined implementations `color.RGBA` and `color.RGBAModel`. These interfaces and types are specified by the [[/pkg/image/color/][image/color package]]
+The `color.Color` and `color.Model` types are also interfaces, but we'll ignore that by using the predefined implementations `color.RGBA` and `color.RGBAModel`. These interfaces and types are specified by the [[https://go.dev/pkg/image/color/][image/color package]]
 
 .play methods/images.go
 
@@ -405,7 +405,7 @@ The `color.Color` and `color.Model` types are also interfaces, but we'll ignore 
 
 Remember the [[/tour/moretypes/18][picture generator]] you wrote earlier? Let's write another one, but this time it will return an implementation of `image.Image` instead of a slice of data.
 
-Define your own `Image` type, implement [[/pkg/image/#Image][the necessary methods]], and call `pic.ShowImage`.
+Define your own `Image` type, implement [[https://go.dev/pkg/image/#Image][the necessary methods]], and call `pic.ShowImage`.
 
 `Bounds` should return a `image.Rectangle`, like `image.Rect(0,`0,`w,`h)`.
 

--- a/_content/tour/moretypes.article
+++ b/_content/tour/moretypes.article
@@ -214,7 +214,7 @@ Slices can contain any type, including other slices.
 * Appending to a slice
 
 It is common to append new elements to a slice, and so Go provides a built-in
-`append` function. The [[/pkg/builtin/#append][documentation]]
+`append` function. The [[https://go.dev/pkg/builtin/#append][documentation]]
 of the built-in package describes `append`.
 
 	func append(s []T, vs ...T) []T
@@ -229,7 +229,7 @@ If the backing array of `s` is too small to fit all the given values a bigger
 array will be allocated. The returned slice will point to the newly allocated
 array.
 
-(To learn more about slices, read the [[/blog/go-slices-usage-and-internals][Slices: usage and internals]] article.)
+(To learn more about slices, read the [[https://go.dev/blog/go-slices-usage-and-internals][Slices: usage and internals]] article.)
 
 .play moretypes/append.go
 
@@ -324,7 +324,7 @@ If `key` is not in the map, then `elem` is the zero value for the map's element 
 
 Implement `WordCount`.  It should return a map of the counts of each “word” in the string `s`. The `wc.Test` function runs a test suite against the provided function and prints success or failure.
 
-You might find [[/pkg/strings/#Fields][strings.Fields]] helpful.
+You might find [[https://go.dev/pkg/strings/#Fields][strings.Fields]] helpful.
 
 .play moretypes/exercise-maps.go
 

--- a/_content/tour/welcome.article
+++ b/_content/tour/welcome.article
@@ -6,7 +6,7 @@ https://golang.org
 
 * Hello, 世界
 
-Welcome to a tour of the [[/][Go programming language]].
+Welcome to a tour of the [[https://go.dev/][Go programming language]].
 
 The tour is divided into a list of modules that you can
 access by clicking on
@@ -36,7 +36,7 @@ Edit the program and run it again.
 
 When you click on [[javascript:highlightAndClick("#format")][Format]]
 (shortcut: `Ctrl` + `Enter`), the text in the editor is formatted using the
-[[/cmd/gofmt/][gofmt]] tool. You can switch syntax highlighting on and off
+[[https://go.dev/cmd/gofmt/][gofmt]] tool. You can switch syntax highlighting on and off
 by clicking on the [[javascript:highlightAndClick(".syntax-checkbox")][syntax]] button.
 
 When you're ready to move on, click the [[javascript:highlightAndClick(".next-page")][right arrow]] below or type the `PageDown` key.


### PR DESCRIPTION
Lots of links in the tour use origin-relative links on the assumption they will be used at "https://go.dev/", which works out badly if the tour is being used offline. Links inside of "#appengine:" don't need to be updated as they will be running inside the normal location.  Also don't have to update links starting with "/tour" as they will work in the offline and appengine modes.

I did consider updating the links to the place they currently redirect for links like "https://go.dev/pkg/builtin" which ends up at "https://pkg.go.dev/builtin" but it is redirecting with 307 Temporary Redirect (unlike the 301 Moved Permanently "https://golang.org/" gets) so I avoided those updates.

Update origin-relative links that will appear offline to be absolute https://go.dev links.

Fixes golang/tour#1463