### PR TITLE
[ISSUE #58991]_content/doc: add missing 'the' in sentence

### DIFF
--- a/_content/doc/effective_go.html
+++ b/_content/doc/effective_go.html
@@ -2314,7 +2314,7 @@ func ArgServer(w http.ResponseWriter, req *http.Request) {
 }
 </pre>
 <p>
-<code>ArgServer</code> now has same signature as <code>HandlerFunc</code>,
+<code>ArgServer</code> now has the same signature as <code>HandlerFunc</code>,
 so it can be converted to that type to access its methods,
 just as we converted <code>Sequence</code> to <code>IntSlice</code>
 to access <code>IntSlice.Sort</code>.


### PR DESCRIPTION
Fix [](https://github.com/golang/go/issues/58991)

added missing "the" in sentence