### PR TITLE
_content/doc: remove "Accessing databases" heading 3

### DIFF
--- a/_content/doc/index.html
+++ b/_content/doc/index.html
@@ -128,7 +128,6 @@ Main documentation page for coverage testing of Go applications.
 Main documentation page for profile-guided optimization (PGO) of Go applications.
 </p>
 
-<h3 id="data-access">Accessing databases</h3>
 </section>
 
 


### PR DESCRIPTION
There is a specific "card" dedicated to "Accessing databases" in Go (section: "data-access").
It appears the "card": Using and understanding Go (section: "learning") - by mistake - (also) contains the header 3 text: "Accessing databases" at the bottom of the card.

![image](https://user-images.githubusercontent.com/220023/224720724-d7139ca2-9e76-45d4-87c3-eaec58b17441.png)
