### PR TITLE
tour: document modern way to start offline tour

### DIFF
--- a/tour/README.md
+++ b/tour/README.md
@@ -16,16 +16,18 @@ This will place a `tour` binary in your
 [GOPATH](https://go.dev/cmd/go/#hdr-GOPATH_and_Modules)'s `bin` directory.
 The tour program can be run offline.
 
+## Running Locally
+
+To run the tour server locally (from the `GOPATH/bin` directory as above):
+
+	tour
+
+Your browser should now open. If not, please visit [http://localhost:3999/](http://localhost:3999).
+
 ## Send Patches
 
 This repository uses Gerrit for code changes. To learn how to submit changes to
 this repository, see https://go.dev/doc/contribute.
-
-To run the tour server locally:
-
-	go run .
-
-Your browser should now open. If not, please visit [http://localhost:3999/](http://localhost:3999).
 
 ## Report Issues
 


### PR DESCRIPTION
In 2018 tour/README.md got a update to look like the then existing blog/README.md and the section got accidently placed under the patching header (wrong location) and lost the header it had in blog/README.md. At the time it was also still a python app.yaml command which, later updated to be a "go run .", which no longer matches with the install instructions for the tour which generate a "tour" binary file to run.

Add "Running Locally" header in (matching old blog/README.md style) after the "Download/Install" and move local run instructions to that new section while changing command to "tour" that is installed.