### PR TITLE
tour: add blog links for generics for context

### DIFF
--- a/_content/tour/generics.article
+++ b/_content/tour/generics.article
@@ -28,6 +28,9 @@ In addition to generic functions, Go also supports generic types. A type can
 be parameterized with a type parameter, which could be useful for implementing
 generic data structures.
 
+(To learn more about generics, read the [[https://go.dev/blog/intro-generics][An Introduction To Generics]]
+and [[https://go.dev/blog/when-generics][When To Use Generics]] articles.)
+
 This example demonstrates a simple type declaration for a singly-linked list
 holding any type of value.
 


### PR DESCRIPTION
The tour slides are slim for generics, adding links to the blog articles about generics similar to how "/tour/moretypes/15" links to the blog on slices adds a place to expand the the readers knowledge.

Added links to generics blog entries on last generics slide.