### PR TITLE
tour: link to time doc for After/Tick

### DIFF
--- a/_content/tour/concurrency.article
+++ b/_content/tour/concurrency.article
@@ -90,6 +90,8 @@ Use a `default` case to try a send or receive without blocking:
 		// receiving from c would block
 	}
 
+The [[https://pkg.go.dev/time#pkg-functions][`time` package documentation]] may be helpful.
+
 .play concurrency/default-selection.go
 
 * Exercise: Equivalent Binary Trees


### PR DESCRIPTION
On the tour slide "tour/concurrency/6" ("Default Selection") the example code in "default-selection.go" uses time.After() and time.Tick() without any mention of what they do. A link to the time fuctions doc can provide context to understand what those do.

Add link to time#pkg-functions on slide next to code using time.After()/Tick().

Fixes golang/tour#1466