### PR TITLE
_content/doc: remove extra < in HTML formatting

### DIFF
--- a/_content/doc/go1.20.html
+++ b/_content/doc/go1.20.html
@@ -917,7 +917,7 @@ proxyHandler := &httputil.ReverseProxy{
       the total number of headers in all <code>FileHeaders</code> to 10000.
       These limits may be adjusted with the <code>GODEBUG=multipartmaxheaders</code>
       setting.
-      <code>Reader.ReadForm</code<> further limits the number of parts in a form to 1000.
+      <code>Reader.ReadForm</code> further limits the number of parts in a form to 1000.
       This limit may be adjusted with the <code>GODEBUG=multipartmaxparts</code>
       setting.
     </p>


### PR DESCRIPTION
Typo from an update last week, remove an extra '<'.

Fixes golang/go#59534