### PR TITLE
_content/doc: remove second extra < in HTML

### DIFF
--- a/_content/doc/go1.19.html
+++ b/_content/doc/go1.19.html
@@ -704,7 +704,7 @@ as well as support for rendering them to HTML, Markdown, and text.
       the total number of headers in all <code>FileHeaders</code> to 10000.
       These limits may be adjusted with the <code>GODEBUG=multipartmaxheaders</code>
       setting.
-      <code>Reader.ReadForm</code<> further limits the number of parts in a form to 1000.
+      <code>Reader.ReadForm</code> further limits the number of parts in a form to 1000.
       This limit may be adjusted with the <code>GODEBUG=multipartmaxparts</code>
       setting.
     </p>


### PR DESCRIPTION
Commit 18b7f5b1d41 from last week, updated the release notes for 1.19 and 
1.20 which included a copy/paste HTML formatting error, fixing the second 
place here. Also verified these were the only two places in website that got
this typo. The comment version of this in go repo is not HTML formatted, so
no typo.

Typo from an update last week, remove an second extra '<'.

Updates golang/go#59534