### PR TITLE
Fix broken format on mobile fuzz doc page

### DIFF
--- a/_content/security/fuzz/index.md
+++ b/_content/security/fuzz/index.md
@@ -24,13 +24,11 @@ components.
 <img class="DarkMode-img" alt="Example code showing the overall fuzz test, with a fuzz target within
 it. Before the fuzz target is a corpus addition with f.Add, and the parameters
 of the fuzz target are highlighted as the fuzzing arguments."
-src="/security/fuzz/example-dark.png" style="width: 600px; height:
-auto;"/>
+src="/security/fuzz/example-dark.png" width="85%"/>
 <img alt="Example code showing the overall fuzz test, with a fuzz target within
 it. Before the fuzz target is a corpus addition with f.Add, and the parameters
 of the fuzz target are highlighted as the fuzzing arguments."
-src="/security/fuzz/example.png" style="width: 600px; height:
-auto;" class="LightMode-img"/>
+src="/security/fuzz/example.png" width="85%" class="LightMode-img"/>
 
 ## Writing fuzz tests
 


### PR DESCRIPTION
The doc page for Fuzzing includes an png image that was overflowing on mobile and making reading the page difficult on a phone. This minor change changes the image scaling to a percent value so that the image stays inside the bounds.