### PR TITLE
_content/tour: add a link to the Ukraininan translation

### DIFF
--- a/_content/tour/welcome.article
+++ b/_content/tour/welcome.article
@@ -56,6 +56,7 @@ The tour is available in other languages:
 - [[https://go-tour-ko.appspot.com/][Korean — 한국어]]
 - [[https://go-tour-pl1.appspot.com/][Polish — Polski]]
 - [[https://go-tour-th.appspot.com/][Thai — ภาษาไทย]]
+- [[https://go-tour-ua-translation.lm.r.appspot.com/][Ukrainian — Українською]]
 
 Click the [[javascript:highlightAndClick(".next-page")]["next"]] button or type `PageDown` to continue.
 


### PR DESCRIPTION
Add a link to the Ukrainian translation to "A Tour of Go".

Link: https://go-tour-ua-translation.lm.r.appspot.com

Fixes golang/go#59945.