### PR TITLE
_content/doc/tutorial: remove unused import "time"

### DIFF
--- a/_content/doc/tutorial/greetings-multiple-people.html
+++ b/_content/doc/tutorial/greetings-multiple-people.html
@@ -40,7 +40,6 @@ import (
     "errors"
     "fmt"
     "math/rand"
-    "time"
 )
 
 // Hello returns a greeting for the named person.


### PR DESCRIPTION
`Time` was used by `math/rand.Seed` that is removed