### PR TITLE
_content/doc/tutorial: remove unused import "time"

### DIFF
--- a/_content/doc/tutorial/random-greeting.html
+++ b/_content/doc/tutorial/random-greeting.html
@@ -36,8 +36,7 @@ package greetings
 import (
     "errors"
     "fmt"
-    <ins>"math/rand"
-    "time"</ins>
+    <ins>"math/rand"</ins>
 )
 
 // Hello returns a greeting for the named person.


### PR DESCRIPTION
`Time` was used by `math/rand.Seed` that is removed