### PR TITLE
_content/doc/tutorial: remove mention of init function

### DIFF
--- a/_content/doc/tutorial/random-greeting.html
+++ b/_content/doc/tutorial/random-greeting.html
@@ -92,13 +92,6 @@ func randomFormat() string {
         to generate a random number for selecting an item from the slice.
       </li>
       <li>
-        Add an <code>init</code> function to seed the <code>rand</code> package
-        with the current time. Go executes <code>init</code> functions
-        automatically at program startup, after global variables have been
-        initialized. For more about <code>init</code> functions, see
-        <a href="/doc/effective_go.html#init">Effective Go</a>.
-      </li>
-      <li>
         In <code>Hello</code>, call the <code>randomFormat</code> function to
         get a format for the message you'll return, then use the format and
         <code>name</code> value together to create the message.


### PR DESCRIPTION
the init function is removed from the code example: https://github.com/golang/website/commit/f7341273feb9c0d7d7e12a52d975e7834bf32aa1