### PR TITLE
_content/doc/install.html: eliminate redundant link

### DIFF
--- a/_content/doc/install.html
+++ b/_content/doc/install.html
@@ -26,10 +26,6 @@
     </span>
   </a>
 </p>
-<p>
-  Don't see your operating system here? Try one of the
-  <a href="/dl/">other downloads</a>.
-</p>
 
 <h2 id="install">Go installation</h2>
 <p>


### PR DESCRIPTION
I have just remove this paragraph:
"Don't see your operating system here? Try one of the other downloads." Some newbies are confuse by this so better remove it because it leads to the same page to  "Download (1.20.6)".

Fixes golang/go#61311