### PR TITLE
_content/doc/tutorial: fix govunlcheck links.

### DIFF
--- a/_content/doc/tutorial/index.html
+++ b/_content/doc/tutorial/index.html
@@ -77,7 +77,7 @@
     </tr>
     <tr class="DocTable-row">
       <td class="DocTable-cell">
-        <a href="doc/tutorial/govulncheck">Getting started with govulncheck</a>
+        <a href="/doc/tutorial/govulncheck">Getting started with govulncheck</a>
       </td>
       <td class="DocTable-cell">Introduces how to find and fix vulnerabilities
         with govulncheck. Govulncheck reports known vulnerabilities that affect
@@ -85,7 +85,7 @@
     </tr>
     <tr class="DocTable-row">
       <td class="DocTable-cell">
-        <a href="doc/tutorial/govulncheck-ide">Find and fix vulnerable dependencies with VS Code Go</a>
+        <a href="/doc/tutorial/govulncheck-ide">Find and fix vulnerable dependencies with VS Code Go</a>
       </td>
       <td class="DocTable-cell">Introduces how to find and fix vulnerable
         dependencies directly from your IDE with VS Code Go and Vim.</td>


### PR DESCRIPTION
Currently, the website throws a 404 if the user clicks on either govulncheck link from the main tutorial page [0,1,2].

[0] https://go.dev/doc/tutorial/doc/tutorial/govulnchec
[1] https://go.dev/doc/tutorial/doc/tutorial/govulncheck
[2] https://go.dev/doc/tutorial/doc/tutorial/govulncheck-ide 