### PR TITLE
_content: fix error preventing some features to load in dl page

### DIFF
--- a/_content/js/site.js
+++ b/_content/js/site.js
@@ -213,18 +213,18 @@ window.initFuncs = [];
     const textarea = document.getElementById('code');
     const preContainer = document.querySelector('.Playground-preContainer');
 
-    textarea.addEventListener('keydown', e => {
+    textarea?.addEventListener('keydown', e => {
       if (e.key === 'Escape') {
         e.preventDefault();
         textarea.blur();
       }
     });
 
-    textarea.addEventListener('blur', () => {
+    textarea?.addEventListener('blur', () => {
       preContainer.style.display = 'none';
     });
-    
-    textarea.addEventListener('focus', () => {
+
+    textarea?.addEventListener('focus', () => {
       preContainer.style.display = 'block';
     });
   }
@@ -356,13 +356,13 @@ window.initFuncs = [];
         }
         document.cookie = `cookie-consent=true;${domain}path=/;max-age=31536000`;
         notice.remove();
-      })
+      });
     }
   }
 
   initialThemeSetup();
 
-  window.addEventListener('DOMContentLoaded', () => {
+  const onPageLoad = () => {
     registerHeaderListeners();
     registerPlaygroundListeners();
     setDownloadLinks();
@@ -370,5 +370,14 @@ window.initFuncs = [];
     setVersionSpans();
     registerPortToggles();
     registerCookieNotice();
-  });
+  };
+
+  // DOM might be already loaded when try to setup the callback, hence the check.
+  if (document.readyState !== 'loading') {
+    onPageLoad();
+  } else {
+    document.addEventListener('DOMContentLoaded', function () {
+      onPageLoad();
+    });
+  }
 })();

--- a/_content/js/site.js
+++ b/_content/js/site.js
@@ -372,7 +372,7 @@ window.initFuncs = [];
     registerCookieNotice();
   };
 
-  // DOM might be already loaded when try to setup the callback, hence the check.
+  // DOM might be already loaded when we try to setup the callback, hence the check.
   if (document.readyState !== 'loading') {
     onPageLoad();
   } else {

--- a/_content/js/site.js
+++ b/_content/js/site.js
@@ -376,8 +376,6 @@ window.initFuncs = [];
   if (document.readyState !== 'loading') {
     onPageLoad();
   } else {
-    document.addEventListener('DOMContentLoaded', function () {
-      onPageLoad();
-    });
+    document.addEventListener('DOMContentLoaded', onPageLoad);
   }
 })();


### PR DESCRIPTION
There was an error when setting up the callback for page load in the /dl page, preventing some features to load properly. The error was due to some methods being invoked for the playground textarea field, that for this specific page is not in the dom.

Updated the logic for page load to wait for dom content loaded or check document.readyState since the page might be loaded already when we try to set up the callback.

Fixes: golang/go#61587