### PR TITLE
_content/doc: copypaste.js included more than once

### DIFF
--- a/_content/doc/install.html
+++ b/_content/doc/install.html
@@ -219,4 +219,3 @@
 
 <script async src="/doc/download.js"></script>
 <script async src="/doc/hats.js"></script>
-<script async src="/js/copypaste.js"></script>


### PR DESCRIPTION
The copypaste js script is included twice, once in the site.tmpl and a second time in install.html.