### PR TITLE
_content/doc/go1.21: fix links

### DIFF
--- a/_content/doc/go1.21.html
+++ b/_content/doc/go1.21.html
@@ -20,7 +20,7 @@ Do not send CLs removing the interior tags from such phrases.
   The latest Go release, version 1.21, arrives six months after <a href="/doc/go1.20">Go 1.20</a>.
   Most of its changes are in the implementation of the toolchain, runtime, and libraries.
   As always, the release maintains the Go 1 <a href="/doc/go1compat">promise of compatibility</a>;
-  in fact, Go 1.21 <a href="#godebug">improves upon that promise</a>.
+  in fact, Go 1.21 <a href="#tools">improves upon that promise</a>.
   We expect almost all Go programs to continue to compile and run as before.
 </p>
 
@@ -47,13 +47,13 @@ Do not send CLs removing the interior tags from such phrases.
       smallest (or largest, for <code>max</code>) value of a fixed number
       of given arguments.
       See the language spec for
-      <a href="https://tip.golang.org/ref/spec#Min_and_max">details</a>.
+      <a href="/ref/spec#Min_and_max">details</a>.
     </li>
     <li><!-- https://go.dev/issue/56351 -->
       The new function <code>clear</code> deletes all elements from a
       map or zeroes all elements of a slice.
       See the language spec for
-      <a href="https://tip.golang.org/ref/spec#Clear">details</a>.
+      <a href="/ref/spec#Clear">details</a>.
     </li>
   </ul>
 </p>
@@ -131,7 +131,7 @@ Do not send CLs removing the interior tags from such phrases.
 
 <p><!-- https://go.dev/issue/58650 -->
   More generally, the description of
-  <a href="https://tip.golang.org/ref/spec#Type_inference">type inference</a>
+  <a href="/ref/spec#Type_inference">type inference</a>
   in the language spec has been clarified.
   Together, all these changes make type inference more powerful and inference failures less surprising.
 </p>


### PR DESCRIPTION
* fix godebug link
* fix spec links

Fixes golang/go#61880