### PR TITLE
internal/dl: update system requirements

### DIFF
--- a/internal/dl/dl.go
+++ b/internal/dl/dl.go
@@ -170,7 +170,7 @@ var featuredFiles = []Feature{
 	},
 	{
 		Platform:     "Apple macOS (x86-64)",
-		Requirements: "macOS 10.13 or later, Intel 64-bit processor",
+		Requirements: "macOS 10.15 or later, Intel 64-bit processor",
 		fileRE:       regexp.MustCompile(`\.darwin-amd64\.pkg$`),
 	},
 	{

--- a/internal/dl/dl.go
+++ b/internal/dl/dl.go
@@ -160,7 +160,7 @@ type Feature struct {
 var featuredFiles = []Feature{
 	{
 		Platform:     "Microsoft Windows",
-		Requirements: "Windows 7 or later, Intel 64-bit processor",
+		Requirements: "Windows 10 or later, Intel 64-bit processor",
 		fileRE:       regexp.MustCompile(`\.windows-amd64\.msi$`),
 	},
 	{


### PR DESCRIPTION
As described at https://go.dev/doc/go1.21#ports:

- Go 1.21 requires at least Windows 10 or Windows Server 2016;
  support for previous versions has been discontinued.
- Go 1.21 requires macOS 10.15 Catalina or later;
  support for previous versions has been discontinued.

For golang/go#23011.
For golang/go#52188.