### PR TITLE
_content/doc/go1.21: remove redundant close bracket

### DIFF
--- a/_content/doc/go1.21.html
+++ b/_content/doc/go1.21.html
@@ -235,7 +235,7 @@ Do not send CLs removing the interior tags from such phrases.
   The <code>go</code> <code>test</code> <code>-c</code> flag now
   supports writing test binaries for multiple packages, each to
   <code>pkg.test</code> where <code>pkg</code> is the package name.
-  It is an error if more than one test package being compiled has a given package name.]
+  It is an error if more than one test package being compiled has a given package name.
 </p>
 
 <p><!-- https://go.dev/issue/15513, CL 466397 -->


### PR DESCRIPTION
This added by https://go-review.googlesource.com/c/go/+/500956. But there is not an open bracket. 
I assume this is just a typo.