### PR TITLE
_content/ref/mod.md: add clear warning against checking `go.work` into VCS

### DIFF
--- a/_content/ref/mod.md
+++ b/_content/ref/mod.md
@@ -1176,6 +1176,10 @@ edits. The
 [`golang.org/x/mod/modfile`](https://pkg.go.dev/golang.org/x/mod/modfile?tab=doc)
 package can be used by Go programs to make the same changes programmatically.
 
+`go.work` files should not be checked into version control repos containing modules
+so that the `go.work` file in a module does not end up overriding the configuration 
+a user created themselves outside of the module.
+
 ### Lexical elements {#go-work-file-lexical}
 
 Lexical elements in `go.work` files are defined in exactly the same way [as for


### PR DESCRIPTION
Since the original proposal strongly suggests against checking go.work into VCS: https://go.googlesource.com/proposal/+/master/design/45713-workspace.md#rationale-the-file.


> `go.work` files should not be checked into version control repos containing modules so that the `go.work` file in a module does not end up overriding the configuration a user created themselves outside of the module. The `go.work` documentation should contain clear warnings about this.

This PR is inspired by the recent Reddit discussion: https://www.reddit.com/r/golang/comments/15v8i06/why_gowork_file_should_not_be_committed/

Fixes golang/go#62179