### PR TITLE
_content/tour: add dark theme cursor and selection styles

### DIFF
--- a/_content/tour/static/css/app.css
+++ b/_content/tour/static/css/app.css
@@ -396,6 +396,13 @@ a#run, a#kill {
 [data-theme='dark'] .cm-s-default .cm-comment {
     color: #fb6;
 }
+
+[data-theme='dark'] .CodeMirror-cursor { border-color: #BABABA; }
+[data-theme='dark'] .CodeMirror-selected { background: #55483a; }
+[data-theme='dark'] .CodeMirror-focused .CodeMirror-selected { background: #433425; }
+[data-theme='dark'] .CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background: #433425; }
+[data-theme='dark'] .CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection { background: #433425; }
+
 @media (min-width: 601px) {
     #editor-container {
         position: fixed;


### PR DESCRIPTION
Add styles for dark theme cursor and selection.
Cursor color set equal to the foreground color.
Focused selection color set to the complement color
of the background color and inactive selection
is the lighter tint of it.

Fixes golang/go#63313