### PR TITLE
_content/doc/articles/race_detector: document linux/s390x support

### DIFF
--- a/_content/doc/articles/race_detector.html
+++ b/_content/doc/articles/race_detector.html
@@ -417,9 +417,10 @@ close(c)
   systems requires an installed C compiler.
   The race detector supports
   <code>linux/amd64</code>, <code>linux/ppc64le</code>,
-  <code>linux/arm64</code>, <code>freebsd/amd64</code>,
-  <code>netbsd/amd64</code>, <code>darwin/amd64</code>,
-  <code>darwin/arm64</code>, and <code>windows/amd64</code>.
+  <code>linux/arm64</code>, <code>linux/s390x</code>,
+  <code>freebsd/amd64</code>, <code>netbsd/amd64</code>,
+  <code>darwin/amd64</code>, <code>darwin/arm64</code>,
+  and <code>windows/amd64</code>.
 </p>
 
 <p>


### PR DESCRIPTION
Support for linux/s390x was added in Go 1.19.