### PR TITLE
fix: use proper verbs in printing

### DIFF
--- a/_content/tour/basics/type-inference.go
+++ b/_content/tour/basics/type-inference.go
@@ -6,5 +6,5 @@ import "fmt"
 
 func main() {
 	v := 42 // change me!
-	fmt.Printf("v is of type %T\n", v)
+	fmt.Printf("%v is of type %T\n", v, v)
 }


### PR DESCRIPTION
Fix printing output to show the value and type in the output properly