### PR TITLE
_content: fix markdown styling with dark theme under /src

### DIFF
--- a/_content/src/default.tmpl
+++ b/_content/src/default.tmpl
@@ -1,0 +1,3 @@
+{{define "layout"}}
+{{doclayout .}}
+{{end}}


### PR DESCRIPTION
This adds a template for markdown files under the go.dev/src path

Font color is set by a css variable under an Article selector.
The previous implementation did apply the Article class to pages
under the /src path. 

By creating a default template pages will respect theme font colors.

Fixes golang/go#64929