### PR TITLE
_content/doc/database: add missing err in fmt.Errorf call

### DIFF
--- a/_content/doc/database/querying.md
+++ b/_content/doc/database/querying.md
@@ -50,7 +50,7 @@ func canPurchase(id int, quantity int) (bool, error) {
 		if err == sql.ErrNoRows {
 			return false, fmt.Errorf("canPurchase %d: unknown album", id)
 		}
-		return false, fmt.Errorf("canPurchase %d: %v", id)
+		return false, fmt.Errorf("canPurchase %d: %v", id, err)
 	}
 	return enough, nil
 }


### PR DESCRIPTION
There's a %v in the format string, but the err variable wasn't included.

Fixes golang/go#65016