### PR TITLE
Update package name

### DIFF
--- a/_content/doc/tutorial/getting-started.html
+++ b/_content/doc/tutorial/getting-started.html
@@ -217,7 +217,7 @@ $ go help
       </li>
       <li>
         Locate and click the <code>rsc.io/quote</code> package in search results
-        (if you see <code>rsc.io/quote/v3</code>, ignore it for now).
+        (if you see <code>rsc.io/quote/v4</code>, ignore it for now).
       </li>
       <li>
         In the <strong>Documentation</strong> section, under <strong>Index</strong>, note the


### PR DESCRIPTION
Updated package name in go tutorials, v3 -> v4

![image](https://github.com/golang/website/assets/73871477/6a1d8a7f-2279-4fd4-9ca6-319b8657f875)

https://pkg.go.dev/rsc.io/quote/v4