### PR TITLE
_content/doc: use mysql.NewConfig() instead of mysql.Config{}

### DIFF
--- a/_content/doc/database/open-handle.md
+++ b/_content/doc/database/open-handle.md
@@ -115,13 +115,12 @@ to build a connection string.
 
 ```
 // Specify connection properties.
-cfg := mysql.Config{
-	User:   username,
-	Passwd: password,
-	Net:    "tcp",
-	Addr:   "127.0.0.1:3306",
-	DBName: "jazzrecords",
-}
+cfg := mysql.NewConfig()
+cfg.User = username
+cfg.Passwd = password
+cfg.Net = "tcp"
+cfg.Addr = "127.0.0.1:3306"
+cfg.DBName = "jazzrecords"
 
 // Get a database handle.
 db, err = sql.Open("mysql", cfg.FormatDSN())
@@ -143,13 +142,12 @@ create a handle with code such as the following:
 
 ```
 // Specify connection properties.
-cfg := mysql.Config{
-	User:   username,
-	Passwd: password,
-	Net:    "tcp",
-	Addr:   "127.0.0.1:3306",
-	DBName: "jazzrecords",
-}
+cfg := mysql.NewConfig()
+cfg.User = username
+cfg.Passwd = password
+cfg.Net = "tcp"
+cfg.Addr = "127.0.0.1:3306"
+cfg.DBName = "jazzrecords"
 
 // Get a driver-specific connector.
 connector, err := mysql.NewConnector(&cfg)

--- a/_content/doc/tutorial/database-access.md
+++ b/_content/doc/tutorial/database-access.md
@@ -240,14 +240,14 @@ specific database.
     var db *sql.DB
 
     func main() {
-    	// Capture connection properties.
-    	cfg := mysql.Config{
-    		User:   os.Getenv("DBUSER"),
-    		Passwd: os.Getenv("DBPASS"),
-    		Net:    "tcp",
-    		Addr:   "127.0.0.1:3306",
-    		DBName: "recordings",
-    	}
+		// Capture connection properties.
+		cfg := mysql.NewConfig()
+		cfg.User = os.Getenv("DBUSER")
+		cfg.Passwd = os.Getenv("DBPASS")
+		cfg.Net = "tcp"
+		cfg.Addr = "127.0.0.1:3306"
+		cfg.DBName = "recordings"
+
     	// Get a database handle.
     	var err error
     	db, err = sql.Open("mysql", cfg.FormatDSN())
@@ -690,13 +690,13 @@ type Album struct {
 
 func main() {
 	// Capture connection properties.
-	cfg := mysql.Config{
-		User:   os.Getenv("DBUSER"),
-		Passwd: os.Getenv("DBPASS"),
-		Net:    "tcp",
-		Addr:   "127.0.0.1:3306",
-		DBName: "recordings",
-	}
+	cfg := mysql.NewConfig()
+	cfg.User = os.Getenv("DBUSER")
+	cfg.Passwd = os.Getenv("DBPASS")
+	cfg.Net = "tcp"
+	cfg.Addr = "127.0.0.1:3306"
+	cfg.DBName = "recordings"
+
 	// Get a database handle.
 	var err error
 	db, err = sql.Open("mysql", cfg.FormatDSN())

--- a/_content/doc/tutorial/database-access.md
+++ b/_content/doc/tutorial/database-access.md
@@ -240,13 +240,13 @@ specific database.
     var db *sql.DB
 
     func main() {
-		// Capture connection properties.
-		cfg := mysql.NewConfig()
-		cfg.User = os.Getenv("DBUSER")
-		cfg.Passwd = os.Getenv("DBPASS")
-		cfg.Net = "tcp"
-		cfg.Addr = "127.0.0.1:3306"
-		cfg.DBName = "recordings"
+    	// Capture connection properties.
+    	cfg := mysql.NewConfig()
+    	cfg.User = os.Getenv("DBUSER")
+    	cfg.Passwd = os.Getenv("DBPASS")
+    	cfg.Net = "tcp"
+    	cfg.Addr = "127.0.0.1:3306"
+    	cfg.DBName = "recordings"
 
     	// Get a database handle.
     	var err error
@@ -331,7 +331,8 @@ specific database.
 
     ```
     $ go get .
-    go get: added github.com/go-sql-driver/mysql v1.6.0
+    go: added filippo.io/edwards25519 v1.1.0
+    go: added github.com/go-sql-driver/mysql v1.8.1
     ```
 
     Go downloaded this dependency because you added it to the `import`


### PR DESCRIPTION
The zero values for `mysql.Config` is not good for default.

See https://pkg.go.dev/github.com/go-sql-driver/mysql#Config

> If a new Config is created instead of being parsed from a DSN string, the NewConfig function should be used, which sets default values.