### PR TITLE
Large outputs now show vertical scrollbar

### DIFF
--- a/_content/tour/static/css/app.css
+++ b/_content/tour/static/css/app.css
@@ -317,6 +317,8 @@ a#run, a#kill {
     font-family: 'Inconsolata', monospace;
     background: #fafafa;
     margin: 0;
+    overflow: auto;
+    max-height: calc(100% - 52px);
 }
 .output .system {
     color: #888;


### PR DESCRIPTION
The calc(100% - 52px) corrects for the 32px that the .output element sticks out below the bottom of the page, and 20px for for the 10px padding that all pre tags have on the top and bottom. If this isn't corrected for then the vertical scrollbar is rendered below the bottom of the page.