### PR TITLE
_content/tour/flowcontrol/defer.go: add example for arguments eager evaluation

### DIFF
--- a/_content/tour/flowcontrol.article
+++ b/_content/tour/flowcontrol.article
@@ -153,7 +153,7 @@ This construct can be a clean way to write long if-then-else chains.
 
 * Defer
 
-A defer statement defers the execution of a function until the surrounding
+A `defer` statement defers the execution of a function until the surrounding
 function returns.
 
 The deferred call's arguments are evaluated immediately, but the function call

--- a/_content/tour/flowcontrol/defer.go
+++ b/_content/tour/flowcontrol/defer.go
@@ -4,8 +4,13 @@ package main
 
 import "fmt"
 
+func helper() string {
+	fmt.Println("helper")
+	return "world"
+}
+
 func main() {
-	defer fmt.Println("world")
+	defer fmt.Println(helper())
 
 	fmt.Println("hello")
 }


### PR DESCRIPTION
This adds an example in the provided code snippet to demostrate and help user better understand the eager evaluation of the deferred call's arguments.

Also fixes: https://github.com/golang/tour/issues/1558 