### PR TITLE
_content/tour/flowcontrol/switch.go: rename `OS X` to `macOS`

### DIFF
--- a/_content/tour/flowcontrol/switch.go
+++ b/_content/tour/flowcontrol/switch.go
@@ -11,7 +11,7 @@ func main() {
 	fmt.Print("Go runs on ")
 	switch os := runtime.GOOS; os {
 	case "darwin":
-		fmt.Println("OS X.")
+		fmt.Println("macOS.")
 	case "linux":
 		fmt.Println("Linux.")
 	default:


### PR DESCRIPTION
Fixes golang/tour#1616