### PR TITLE
_content/doc/tutorial/generics.md: fix typo

### DIFF
--- a/_content/doc/tutorial/generics.md
+++ b/_content/doc/tutorial/generics.md
@@ -439,7 +439,7 @@ Suggested next topics:
 
 <!--TODO: Update text and link after release.-->
 You can run this program in the
-[Go playground](/play/p/apNmfVwogK0?v=gotip). On the
+[Go playground](/play/p/kuUxcdVHtWg?v=gotip). On the
 playground simply click the **Run** button.
 
 ```

--- a/_content/doc/tutorial/generics.md
+++ b/_content/doc/tutorial/generics.md
@@ -509,7 +509,7 @@ func SumIntsOrFloats[K comparable, V int64 | float64](m map[K]V) V {
 	return s
 }
 
-// SumNumbers sums the values of map m. Its supports both integers
+// SumNumbers sums the values of map m. It supports both integers
 // and floats as map values.
 func SumNumbers[K comparable, V Number](m map[K]V) V {
 	var s V


### PR DESCRIPTION
Fixed a minor typo in a comment in the completed code.

There is no issue related to this PR.