### PR TITLE
_content/doc/manage-install: add a delete Go configs instruction

### DIFF
--- a/_content/doc/manage-install.html
+++ b/_content/doc/manage-install.html
@@ -77,6 +77,14 @@ Under Linux and FreeBSD, edit /etc/profile or $HOME/.profile. If you installed G
 </p>
 
 </li>
+<li>Locate and delete the Go configuration directory.
+
+<p>
+    Go stores its configuration in the user's configuration directory under a folder named "go". For instance, on macOS, this might be ~/Library/Application Support/go.
+    Delete the "go" directory to remove all Go configuration files, including those set by go env -w.
+</p>
+
+</li>
 
 </ol>
 


### PR DESCRIPTION
doc/manage-install: add instruction to delete Go config files saved under a directory "go"

Modern Go versions store configuration in the user's configuration directory, under a directory named "go"
For instance, on macOS, this might be " /Library/Application Support/go"
For example, an "env" file that stores Go configuration as set by "go env -w invocations"
The docs at https://go.dev/doc/manage-install#uninstalling  doesn't mention this.

Fixes [golang/go#65583](https://github.com/golang/go/issues/65583)