### PR TITLE
_content/doc/tutorial: remove the unnecessary cd into home directory instruction

### DIFF
--- a/_content/doc/tutorial/getting-started.html
+++ b/_content/doc/tutorial/getting-started.html
@@ -53,30 +53,9 @@
 </p>
 
 <ol>
-  <li>
-    Open a command prompt and cd to your home directory.
-
-    <p>
-      On Linux or Mac:
-    </p>
-
-    <pre>
-cd
-</pre
-    >
-
-    <p>
-      On Windows:
-    </p>
-
-    <pre>
-cd %HOMEPATH%
-</pre
-    >
-  </li>
 
   <li>
-    Create a hello directory for your first Go source code.
+    Open command prompt. Create a hello directory for your first Go source code.
 
     <p>
       For example, use the following commands:


### PR DESCRIPTION
doc/tutorial/getting-started : Remove the first step mentioning cd into home directory

This can be misleading as it is not mandatory to make a project folder in the home directory.

Fixes : [golang/go#66497](https://github.com/golang/go/issues/66497)

A similar instruction is there [Tutorial: Create a Go module](https://go.dev/doc/tutorial/create-module)
Let me know if I should raise a similar PR for it or make changes to this one.