### PR TITLE
_content/doc/faq: clarify the explanation of method sets

### DIFF
--- a/_content/doc/faq.md
+++ b/_content/doc/faq.md
@@ -1425,19 +1425,17 @@ the language specification.)
 Even in cases where the compiler could take the address of a value
 to pass to the method, if the method modifies the value the changes
 will be lost in the caller.
-As an example, if the `Write` method of
-[`bytes.Buffer`](/pkg/bytes/#Buffer)
-used a value receiver rather than a pointer,
-this code:
+
+As an example, if the code below were valid:
 
 ```
 var buf bytes.Buffer
 io.Copy(buf, os.Stdin)
 ```
 
-would copy standard input into a *copy* of `buf`,
+it would copy standard input into a *copy* of `buf`,
 not into `buf` itself.
-This is almost never the desired behavior.
+This is almost never the desired behavior and is therefore disallowed by the language.
 
 ### What happens with closures running as goroutines? {#closures_and_goroutines}
 


### PR DESCRIPTION
I had a small discussion with @ianlancetaylor here:
https://groups.google.com/g/golang-nuts/c/uon32LDerjM/m/dvg0mxbwAAAJ?utm_medium=email&utm_source=footer

I would like to clarify this entry about method sets a bit because the current explanation is a bit confusing. I believe there is no reason for the Write method of Buffer to use a value receiver. In this case, the sentence about the compiler's ability to implicitly take addresses doesn't make sense. 

What I believe is implied here is a hypothetical situation where the code from the example is allowed by Go, and then it is noted that this makes no sense as the result would be lost in the caller. 