### PR TITLE
Add Go binary path to user profile for easy access

### DIFF
--- a/_content/doc/install.html
+++ b/_content/doc/install.html
@@ -101,7 +101,8 @@
           /etc/profile (for a system-wide installation):
         </p>
         <pre class="CopyPaste">
-          <span>export PATH=$PATH:/usr/local/go/bin</span>
+          <span>echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.profile
+&& source $HOME/.profile</span>
           <button aria-label="Copy and paste the code.">
             <img class="CopyPaste-icon" src="/images/icons/copy-paste.svg" />
             <img class="CopyPaste-icon CopyPaste-icon-dark" src="/images/icons/copy-paste-dark.svg" />


### PR DESCRIPTION
This commit adds the line 'export PATH=$PATH:/usr/local/go/bin' to the user's .profile file. This change ensures that the Go programming language binaries are included in the system's PATH environment variable, allowing users to easily run Go commands from any terminal session. Additionally, the command 'source $HOME/.profile' is executed to apply the changes immediately, enhancing the development workflow by eliminating the need to log out and back in. This is crucial for developers working with Go, as it streamlines the setup process and improves productivity.

```bash
echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.profile && source $HOME/.profile
```