### PR TITLE
_content/doc/tutorial/fuzz: add note about combining characters in example

### DIFF
--- a/_content/doc/tutorial/fuzz.md
+++ b/_content/doc/tutorial/fuzz.md
@@ -465,7 +465,8 @@ func Reverse(s string) string {
 ```
 
 The key difference is that `Reverse` is now iterating over each `rune` in the
-string, rather than each `byte`.
+string, rather than each `byte`. Note that this is just an example, and does not
+handle [combining characters](https://en.wikipedia.org/wiki/Combining_character) correctly.
 
 #### Run the code
 


### PR DESCRIPTION
Currently, the fuzzing tutorial provides a reverse function to use.
This led to some confusion on if it is production ready, which it is not.
Adds a note that the code does not handle combining characters correctly.

Fixes golang/go#69628