### PR TITLE
 database access tutorial: fix function name in error message

### DIFF
--- a/_content/doc/tutorial/database-access.md
+++ b/_content/doc/tutorial/database-access.md
@@ -509,9 +509,9 @@ For SQL statements you know will return at most a single row, you can use
     	row := db.QueryRow("SELECT * FROM album WHERE id = ?", id)
     	if err := row.Scan(&alb.ID, &alb.Title, &alb.Artist, &alb.Price); err != nil {
     		if err == sql.ErrNoRows {
-    			return alb, fmt.Errorf("albumsById %d: no such album", id)
+    			return alb, fmt.Errorf("albumByID %d: no such album", id)
     		}
-    		return alb, fmt.Errorf("albumsById %d: %v", id, err)
+    		return alb, fmt.Errorf("albumByID %d: %v", id, err)
     	}
     	return alb, nil
     }


### PR DESCRIPTION
This pull request fixes the error messages in the database access tutorial, by correcting the function name in the error to match the actual function name.