### PR TITLE
Add dark mode styling to code sample of the tour

### DIFF
--- a/_content/tour/static/css/app.css
+++ b/_content/tour/static/css/app.css
@@ -53,7 +53,7 @@ pre, code {
     color: #333;
     background-color: #fafafa;
 }
-[data-theme='dark'] code, [data-theme='dark'] .info {
+[data-theme='dark'] code, [data-theme='dark'] .info, [data-theme='dark'] #left-side pre {
     background-color: #2B2D2F !important;
     color: #BABABA;
 }


### PR DESCRIPTION
Fixes #1703 
https://github.com/golang/tour/issues/1703

Needed to isolate the styling to '#left-side pre' as CodeMirror also uses <pre> tags.
