### PR TITLE
doc: add a disclamer for the TLS handshake timeouts TL;DR bug in godebug.md

### DIFF
--- a/_content/doc/go1.23.md
+++ b/_content/doc/go1.23.md
@@ -293,6 +293,8 @@ the GODEBUG environment variable.
 The experimental post-quantum key exchange mechanism X25519Kyber768Draft00
 is now enabled by default when [`Config.CurvePreferences`](/pkg/crypto/tls#Config.CurvePreferences) is nil.
 The default can be reverted by adding `tlskyber=0` to the GODEBUG environment variable.
+This is can be useful when dealing with legacy TLS servers that do not handle large records correctly,
+causing a timeout during the handshake (bug known as [TLS post-quantum TL;DR fail](https://tldr.fail/)).
 
 Go 1.23 changed the behavior of [`X509KeyPair`](/pkg/crypto/tls#X509KeyPair) and [`LoadX509KeyPair`](/pkg/crypto/tls#LoadX509KeyPair)
 to populate the [`Certificate.Leaf`](/pkg/crypto/tls#Certificate.Leaf) field of the returned [`Certificate`](/pkg/crypto/tls#Certificate).

--- a/_content/doc/go1.23.md
+++ b/_content/doc/go1.23.md
@@ -293,8 +293,8 @@ the GODEBUG environment variable.
 The experimental post-quantum key exchange mechanism X25519Kyber768Draft00
 is now enabled by default when [`Config.CurvePreferences`](/pkg/crypto/tls#Config.CurvePreferences) is nil.
 The default can be reverted by adding `tlskyber=0` to the GODEBUG environment variable.
-This is can be useful when dealing with legacy TLS servers that do not handle large records correctly,
-causing a timeout during the handshake (bug known as [TLS post-quantum TL;DR fail](https://tldr.fail/)).
+This can be useful when dealing with buggy TLS servers that do not handle large records correctly,
+causing a timeout during the handshake (see [TLS post-quantum TL;DR fail](https://tldr.fail/)).
 
 Go 1.23 changed the behavior of [`X509KeyPair`](/pkg/crypto/tls#X509KeyPair) and [`LoadX509KeyPair`](/pkg/crypto/tls#LoadX509KeyPair)
 to populate the [`Certificate.Leaf`](/pkg/crypto/tls#Certificate.Leaf) field of the returned [`Certificate`](/pkg/crypto/tls#Certificate).

--- a/_content/doc/go1.24.md
+++ b/_content/doc/go1.24.md
@@ -480,8 +480,8 @@ The new post-quantum [`X25519MLKEM768`](/pkg/crypto/tls#X25519MLKEM768) key
 exchange mechanism is now supported and is enabled by default when
 [`Config.CurvePreferences`](/pkg/crypto/tls#Config.CurvePreferences) is nil.
 [GODEBUG setting](/doc/godebug) `tlsmlkem=0` reverts the default.
-This is can be useful when dealing with legacy TLS servers that do not handle large records correctly,
-causing a timeout during the handshake (bug known as [TLS post-quantum TL;DR fail](https://tldr.fail/)).
+This can be useful when dealing with buggy TLS servers that do not handle large records correctly,
+causing a timeout during the handshake (see [TLS post-quantum TL;DR fail](https://tldr.fail/)).
 
 Support for the experimental `X25519Kyber768Draft00` key exchange has been removed.
 

--- a/_content/doc/go1.24.md
+++ b/_content/doc/go1.24.md
@@ -480,6 +480,8 @@ The new post-quantum [`X25519MLKEM768`](/pkg/crypto/tls#X25519MLKEM768) key
 exchange mechanism is now supported and is enabled by default when
 [`Config.CurvePreferences`](/pkg/crypto/tls#Config.CurvePreferences) is nil.
 [GODEBUG setting](/doc/godebug) `tlsmlkem=0` reverts the default.
+This is can be useful when dealing with legacy TLS servers that do not handle large records correctly,
+causing a timeout during the handshake (bug known as [TLS post-quantum TL;DR fail](https://tldr.fail/)).
 
 Support for the experimental `X25519Kyber768Draft00` key exchange has been removed.
 


### PR DESCRIPTION
Relates to https://github.com/golang/go/issues/71257. Since post-quantum TLS algorithms are enabled by default, we should warn about the possible bugs with legacy servers (see https://tldr.fail/)