### PR TITLE
_content/doc/tutorial/add-a-test: make code and doc in sync, add missing link

### DIFF
--- a/_content/doc/tutorial/add-a-test.html
+++ b/_content/doc/tutorial/add-a-test.html
@@ -49,7 +49,7 @@ func TestHelloName(t *testing.T) {
     want := regexp.MustCompile(`\b`+name+`\b`)
     msg, err := Hello("Gladys")
     if !want.MatchString(msg) || err != nil {
-        t.Fatalf(`Hello("Gladys") = %q, %v, want match for %#q, nil`, msg, err, want)
+        t.Errorf(`Hello("Gladys") = %q, %v, want match for %#q, nil`, msg, err, want)
     }
 }
 
@@ -58,7 +58,7 @@ func TestHelloName(t *testing.T) {
 func TestHelloEmpty(t *testing.T) {
     msg, err := Hello("")
     if msg != "" || err == nil {
-        t.Fatalf(`Hello("") = %q, %v, want "", error`, msg, err)
+        t.Errorf(`Hello("") = %q, %v, want "", error`, msg, err)
     }
 }
 </pre
@@ -91,17 +91,16 @@ func TestHelloEmpty(t *testing.T) {
             able to return a valid response message. If the call returns an
             error or an unexpected response message (one that doesn't include
             the name you passed in), you use the <code>t</code> parameter's
-            <a href="https://pkg.go.dev/testing/#T.Fatalf">
-            <code>Fatalf</code> method</a> to print a message to the console
-            and end execution.
+            <a href="https://pkg.go.dev/testing/#T.Errorf">
+            <code>Errorf</code> method</a> to print a message to the console.
           </li>
           <li>
             <code>TestHelloEmpty</code> calls the <code>Hello</code> function
             with an empty string. This test is designed to confirm that your
             error handling works. If the call returns a non-empty string or no
             error, you use the <code>t</code> parameter's
-            <a href="https://pkg.go.dev/testing/#T.Fatalf"><code>Fatalf
-            </code> method</a> to print a message to the console and end execution.
+            <a href="https://pkg.go.dev/testing/#T.Errorf"><code>Errorf
+            </code> method</a> to print a message to the console.
           </li>
         </ul>
       </li>

--- a/_content/doc/tutorial/add-a-test.html
+++ b/_content/doc/tutorial/add-a-test.html
@@ -77,7 +77,7 @@ func TestHelloEmpty(t *testing.T) {
         function. Test function names have the form <code>Test<em>Name</em></code>,
         where <em>Name</em> says something about the specific test. Also, test
         functions take a pointer to the <code>testing</code> package's
-        <a href="https://pkg.go.dev/testing/#T"><code>testing.T</code>
+        <a href="/pkg/testing/#T"><code>testing.T</code>
         type</a> as a parameter. You use this parameter's methods for reporting
         and logging from your test.
       </li>
@@ -91,7 +91,7 @@ func TestHelloEmpty(t *testing.T) {
             able to return a valid response message. If the call returns an
             error or an unexpected response message (one that doesn't include
             the name you passed in), you use the <code>t</code> parameter's
-            <a href="https://pkg.go.dev/testing/#T.Errorf">
+            <a href="/pkg/testing/#T.Errorf">
             <code>Errorf</code> method</a> to print a message to the console.
           </li>
           <li>
@@ -99,7 +99,7 @@ func TestHelloEmpty(t *testing.T) {
             with an empty string. This test is designed to confirm that your
             error handling works. If the call returns a non-empty string or no
             error, you use the <code>t</code> parameter's
-            <a href="https://pkg.go.dev/testing/#T.Errorf"><code>Errorf
+            <a href="/pkg/testing/#T.Errorf"><code>Errorf
             </code> method</a> to print a message to the console.
           </li>
         </ul>

--- a/_content/doc/tutorial/add-a-test.html
+++ b/_content/doc/tutorial/add-a-test.html
@@ -49,7 +49,7 @@ func TestHelloName(t *testing.T) {
     want := regexp.MustCompile(`\b`+name+`\b`)
     msg, err := Hello("Gladys")
     if !want.MatchString(msg) || err != nil {
-        t.Errorf(`Hello("Gladys") = %q, %v, want match for %#q, nil`, msg, err, want)
+        t.Fatalf(`Hello("Gladys") = %q, %v, want match for %#q, nil`, msg, err, want)
     }
 }
 
@@ -58,7 +58,7 @@ func TestHelloName(t *testing.T) {
 func TestHelloEmpty(t *testing.T) {
     msg, err := Hello("")
     if msg != "" || err == nil {
-        t.Errorf(`Hello("") = %q, %v, want "", error`, msg, err)
+        t.Fatalf(`Hello("") = %q, %v, want "", error`, msg, err)
     }
 }
 </pre
@@ -99,8 +99,9 @@ func TestHelloEmpty(t *testing.T) {
             <code>TestHelloEmpty</code> calls the <code>Hello</code> function
             with an empty string. This test is designed to confirm that your
             error handling works. If the call returns a non-empty string or no
-            error, you use the <code>t</code> parameter's <code>Fatalf</code>
-            method to print a message to the console and end execution.
+            error, you use the <code>t</code> parameter's
+            <a href="https://pkg.go.dev/testing/#T.Fatalf"><code>Fatalf
+            </code> method</a> to print a message to the console and end execution.
           </li>
         </ul>
       </li>


### PR DESCRIPTION
- Change documentation to reflect the same function used on code.
- Add missing link to the documentation.