### PR TITLE
_content: show anchor links when hovering over article headers

### DIFF
--- a/_content/css/styles.css
+++ b/_content/css/styles.css
@@ -875,6 +875,10 @@ h1 + h2.subtitle {
 .Article a.Article-idLink {
   opacity: 0;
 }
+.Article h1:hover a.Article-idLink,
+.Article h2:hover a.Article-idLink,
+.Article h3:hover a.Article-idLink,
+.Article h4:hover a.Article-idLink,
 .Article a.Article-idLink:hover {
   opacity: 1;
   padding: 0.2rem;


### PR DESCRIPTION
Previously, users had to hover directly over the ¶ symbol to reveal the
anchor link, making it difficult to discover its existence.

This change updates the CSS to also display the anchor link when hovering
over the entire header text, improving usability.

Fixes golang/go#70827