### PR TITLE
_content/tour/concurrency: add timestamps to default selection example for clearer visualization

### DIFF
--- a/_content/tour/concurrency/default-selection.go
+++ b/_content/tour/concurrency/default-selection.go
@@ -8,17 +8,21 @@ import (
 )
 
 func main() {
+	start := time.Now()
 	tick := time.Tick(100 * time.Millisecond)
 	boom := time.After(500 * time.Millisecond)
+	elapsed := func() time.Duration {
+		return time.Since(start).Round(time.Millisecond)
+	}
 	for {
 		select {
 		case <-tick:
-			fmt.Println("tick.")
+			fmt.Printf("[%6s] tick.\n", elapsed())
 		case <-boom:
-			fmt.Println("BOOM!")
+			fmt.Printf("[%6s] BOOM!\n", elapsed())
 			return
 		default:
-			fmt.Println("    .")
+			fmt.Printf("[%6s]     .\n", elapsed())
 			time.Sleep(50 * time.Millisecond)
 		}
 	}


### PR DESCRIPTION
The existing default selection example lacks clear timing visualization.
This change displays timestamps alongside the output, helping learners
visualize:
- The 50ms intervals of the default case
- The 100ms intervals of the tick case
- The immediate execution after tick events
- The precise 500ms timing of the boom event

Enhances readability and understanding of Go's concurrency timing behavior.

Fixes golang/tour#1733
