### PR TITLE
tour: add a missing period

### DIFF
--- a/_content/tour/methods.article
+++ b/_content/tour/methods.article
@@ -397,7 +397,7 @@ declaration is inside package `image`.
 
 (See [[/pkg/image/#Image][the documentation]] for all the details.)
 
-The `color.Color` and `color.Model` types are also interfaces, but we'll ignore that by using the predefined implementations `color.RGBA` and `color.RGBAModel`. These interfaces and types are specified by the [[/pkg/image/color/][image/color package]]
+The `color.Color` and `color.Model` types are also interfaces, but we'll ignore that by using the predefined implementations `color.RGBA` and `color.RGBAModel`. These interfaces and types are specified by the [[/pkg/image/color/][image/color package]].
 
 .play methods/images.go
 


### PR DESCRIPTION
There is a period missing at the end of a sentence in subsection 24 of the Methods and interfaces section of the tour.

Fixes golang/tour#1730