### PR TITLE
_content/ref/mod: remove old notice on go automatically adding a toolchain directive upon updating the go version line

### DIFF
--- a/_content/ref/mod.md
+++ b/_content/ref/mod.md
@@ -632,9 +632,6 @@ The `toolchain` directive
 only has an effect when the module is the main module and the default toolchain's
 version is less than the suggested toolchain's version.
 
-For reproducibility, the `go` command writes its own toolchain name in a `toolchain` line any time
-it is updating the `go` version in the `go.mod` file (usually during `go get`).
-
 For details, see “[Go toolchains](/doc/toolchain)”.
 
 ```


### PR DESCRIPTION
Since Go 1.25 this is no longer the case.

See [0] and [1].

[0]: https://go.dev/doc/go1.25#go-command
[1]: https://github.com/golang/go/issues/65847