### PR TITLE
chore: fix typo in defer-panic-and-recover.md

### DIFF
--- a/_content/blog/defer-panic-and-recover.md
+++ b/_content/blog/defer-panic-and-recover.md
@@ -103,7 +103,7 @@ Thus, this function returns 2:
 
 	func c() (i int) {
 	    defer func() { i++ }()
-	    return 1
+	    return i
 	}
 
 This is convenient for modifying the error return value of a function; we will see an example of this shortly.


### PR DESCRIPTION
Fixed a minor typo in the code example.

There is no issue related to this PR.