### PR TITLE
Update urfave/cli URL to version 3 in Use Cases

### DIFF
--- a/_content/solutions/clis.md
+++ b/_content/solutions/clis.md
@@ -156,7 +156,7 @@ Viper [supports nested structures](https://scene-si.org/2017/04/20/managing-conf
         url: https://pkg.go.dev/github.com/spf13/viper?tab=overview
         desc: A complete configuration solution for Go applications, designed to work within an app to handle configuration needs and formats
       - text: urfave/cli
-        url: https://pkg.go.dev/github.com/urfave/cli?tab=overview
+        url: https://pkg.go.dev/github.com/urfave/cli/v3/?tab=overview
         desc: A minimal framework for creating and organizing command line Go applications
       - text: delve
         url: https://pkg.go.dev/github.com/go-delve/delve?tab=overview


### PR DESCRIPTION
_content/doc/go1.21: fix [urfave/cli link in "Use Cases"]

The existing link is not the highest tagged version according to pkg.go.dev when you click on the link.

Context: The link on "Use Cases" takes you to v1.22.17 but currently the latest is v3.6.2. When you click on the link on "Use Cases" and look on the top of pkg.go.dev this also shows up: 

<img width="1041" height="400" alt="image" src="https://github.com/user-attachments/assets/628c5cd4-f333-4aea-bc2e-6c3406983df8" />

(I am sorry if I missed something or did something wrong. NOTE: This pull request is not associated with any issue.)

(NOTE: I can't even access Gerrit due to my account being under 18! PLEASE HELP ME!)