### PR TITLE
_content/doc: update PATH docs and restructure manage-install.html

### DIFF
--- a/_content/doc/install.html
+++ b/_content/doc/install.html
@@ -116,6 +116,23 @@
         </p>
       </li>
       <li>
+        To use tools installed via <code>go install</code>, you should also add the Go bin directory (typically <code>$HOME/go/bin</code>) to your <code>PATH</code>.
+        <p>
+          You can do this by adding the following line to your <code>$HOME/.profile</code> or <code>$HOME/.bashrc</code> file:
+        </p>
+        <pre class="CopyPaste">
+          <span>export PATH="$PATH:$(go env GOPATH)/bin"</span>
+          <button aria-label="Copy and paste the code.">
+            <img class="CopyPaste-icon" src="/images/icons/copy-paste.svg" />
+            <img class="CopyPaste-icon CopyPaste-icon-dark" src="/images/icons/copy-paste-dark.svg" />
+          </button>
+        </pre>
+      </li>
+      <li>
+        Restart any open Terminal sessions for the changes to take effect.
+        <p><!-- for consistent spacing --></p>
+      </li>
+      <li>
         Verify that you've installed Go by opening a command prompt and typing
         the following command:
         <pre class="CopyPaste">
@@ -142,13 +159,29 @@
         Go.
         <p>
           The package installs the Go distribution to /usr/local/go. The package
-          should put the /usr/local/go/bin directory in your
-          <code>PATH</code> environment variable. You may need to restart any
-          open Terminal sessions for the change to take effect.
+          adds the /usr/local/go/bin directory to your
+          <code>PATH</code> environment variable by creating a <code>/etc/paths.d/go</code> file.
         </p>
       </li>
       <li>
-        Verify that you've installed Go by opening a command prompt and typing
+        To use tools installed via <code>go install</code>, you should also add the Go bin directory (typically <code>$HOME/go/bin</code>) to your <code>PATH</code>.
+        <p>
+          You can do this by adding the following line to your <code>~/.zshrc</code> or <code>~/.bash_profile</code> file:
+        </p>
+        <pre class="CopyPaste">
+          <span>export PATH="$PATH:$(go env GOPATH)/bin"</span>
+          <button aria-label="Copy and paste the code.">
+            <img class="CopyPaste-icon" src="/images/icons/copy-paste.svg" />
+            <img class="CopyPaste-icon CopyPaste-icon-dark" src="/images/icons/copy-paste-dark.svg" />
+          </button>
+        </pre>
+      </li>
+      <li>
+        Restart any open Terminal sessions for the changes to take effect.
+        <p><!-- for consistent spacing --></p>
+      </li>
+      <li>
+        Verify that you've installed Go by opening a <strong>new</strong> Terminal session and typing
         the following command:
         <pre class="CopyPaste">
           <span>$ go version</span>

--- a/_content/doc/install.html
+++ b/_content/doc/install.html
@@ -76,9 +76,9 @@
   >
     <ol>
       <li>
-        <strong>Remove any previous Go installation</strong> by deleting the /usr/local/go folder
-		(if it exists), then extract the archive you just downloaded into /usr/local, creating a fresh
-		Go tree in /usr/local/go:
+        <strong>Remove any previous Go installation</strong> by deleting the <code>/usr/local/go</code> folder
+		(if it exists), then extract the archive you just downloaded into <code>/usr/local</code>, creating a fresh
+		Go tree in <code>/usr/local/go</code>:
 		<pre class="CopyPaste">
       <span>$ rm -rf /usr/local/go &amp;&amp; tar -C /usr/local -xzf <span id="linux-filename">go1.14.3.linux-amd64.tar.gz</span></span>
       <button aria-label="Copy and paste the code.">
@@ -90,15 +90,15 @@
           (You may need to run each command separately with the necessary permissions, as root or through <code>sudo</code>.)
         </p>
 		<p>
-		  <strong>Do not</strong> untar the archive into an existing /usr/local/go tree. This is known to
+		  <strong>Do not</strong> untar the archive into an existing <code>/usr/local/go</code> tree. This is known to
 		  produce broken Go installations.
 		 </p>
       </li>
       <li>
-        Add /usr/local/go/bin to the <code>PATH</code> environment variable.
+        Add <code>/usr/local/go/bin</code> to the <code>PATH</code> environment variable.
         <p>
-          You can do this by adding the following line to your $HOME/.profile or
-          /etc/profile (for a system-wide installation):
+          You can do this by adding the following line to your <code>$HOME/.profile</code> or
+          <code>/etc/profile</code> (for a system-wide installation):
         </p>
         <pre class="CopyPaste">
           <span>export PATH=$PATH:/usr/local/go/bin</span>
@@ -116,7 +116,10 @@
         </p>
       </li>
       <li>
-        To use tools installed via <code>go install</code>, you should also add the Go bin directory (typically <code>$HOME/go/bin</code>) to your <code>PATH</code>.
+        <!-- TODO: Update to GOBIN once go.dev/issue/23439 is addressed. -->
+        Add <code>$HOME/go/bin</code> (the default Go bin path) to your
+        <code>PATH</code> environment variable to use tools installed via
+        <code>go install</code>.
         <p>
           You can do this by adding the following line to your <code>$HOME/.profile</code> or <code>$HOME/.bashrc</code> file:
         </p>
@@ -129,7 +132,7 @@
         </pre>
       </li>
       <li>
-        Restart any open Terminal sessions for the changes to take effect.
+        Restart any open terminal sessions for the changes to take effect.
         <p><!-- for consistent spacing --></p>
       </li>
       <li>
@@ -158,13 +161,16 @@
         Open the package file you downloaded and follow the prompts to install
         Go.
         <p>
-          The package installs the Go distribution to /usr/local/go. The package
-          adds the /usr/local/go/bin directory to your
+          The package installs the Go distribution to <code>/usr/local/go</code>. The package
+          adds the <code>/usr/local/go/bin</code> directory to your
           <code>PATH</code> environment variable by creating a <code>/etc/paths.d/go</code> file.
         </p>
       </li>
       <li>
-        To use tools installed via <code>go install</code>, you should also add the Go bin directory (typically <code>$HOME/go/bin</code>) to your <code>PATH</code>.
+        <!-- TODO: Update to GOBIN once go.dev/issue/23439 is addressed. -->
+        Add <code>$HOME/go/bin</code> (the default Go bin path) to your
+        <code>PATH</code> environment variable to use tools installed via
+        <code>go install</code>.
         <p>
           You can do this by adding the following line to your <code>~/.zshrc</code> or <code>~/.bash_profile</code> file:
         </p>
@@ -177,11 +183,11 @@
         </pre>
       </li>
       <li>
-        Restart any open Terminal sessions for the changes to take effect.
+        Restart any open terminal sessions for the changes to take effect.
         <p><!-- for consistent spacing --></p>
       </li>
       <li>
-        Verify that you've installed Go by opening a <strong>new</strong> Terminal session and typing
+        Verify that you've installed Go by opening a <strong>new</strong> terminal session and typing
         the following command:
         <pre class="CopyPaste">
           <span>$ go version</span>

--- a/_content/doc/manage-install.html
+++ b/_content/doc/manage-install.html
@@ -76,59 +76,126 @@ Go stores downloaded dependencies in the directory returned by <code>go env GOMO
 These can be removed with <code>go clean -modcache</code>.
 </p>
 
-<h3 id="linux-mac-bsd">Linux / macOS / FreeBSD</h3>
+<div id="os-install-tabs" class="TabSection js-tabSection">
+  <div id="os-install-tablist" class="TabSection-tabList" role="tablist">
+    <button
+      role="tab"
+      aria-selected="true"
+      aria-controls="linux-tab"
+      id="linux"
+      tabindex="0"
+      class="TabSection-tab active"
+    >
+      Linux
+      <img class="TabSection-underline" src="/images/icons/underline.svg" width="51" height="4" aria-hidden="true" />
+    </button>
+    <button
+      role="tab"
+      aria-selected="false"
+      aria-controls="mac-tab"
+      id="mac"
+      tabindex="-1"
+      class="TabSection-tab"
+    >
+      Mac
+      <img class="TabSection-underline" src="/images/icons/underline.svg" width="51" height="4" aria-hidden="true" />
+    </button>
+    <button
+      role="tab"
+      aria-selected="false"
+      aria-controls="windows-tab"
+      id="windows"
+      tabindex="-1"
+      class="TabSection-tab"
+    >
+      Windows
+      <img class="TabSection-underline" src="/images/icons/underline.svg" width="51" height="4" aria-hidden="true" />
+    </button>
+  </div>
 
-<ol>
+  <div
+    role="tabpanel"
+    id="linux-tab"
+    class="TabSection-tabPanel"
+    aria-labelledby="linux"
+  >
+    <ol>
+      <li>Remove <code>/usr/local/go</code>.
+        <p>This is the default installation directory.</p>
+      </li>
+      <li>Remove <code>/usr/local/go</code> from your <code>PATH</code> environment variable.
+        <p>Under Linux and FreeBSD, edit <code>/etc/profile</code> or <code>$HOME/.profile</code>.</p>
+      </li>
+      <li>If you manually added the Go bin directory (typically <code>$HOME/go/bin</code>) to your shell profile, for example by adding <code>export PATH="$PATH:$(go env GOPATH)/bin"</code>, remove that entry.</li>
+      <li>
+        Restart any open Terminal sessions for the changes to take effect.
+        <p><!-- for consistent spacing --></p>
+      </li>
+    </ol>
+  </div>
 
-<li>Delete the go directory.
+  <div
+    role="tabpanel"
+    id="mac-tab"
+    class="TabSection-tabPanel"
+    aria-labelledby="mac"
+    hidden
+  >
+    <ol>
+      <li>Remove <code>/usr/local/go</code>.
+        <p>This is the default installation directory.</p>
+      </li>
+      <li>Remove <code>/usr/local/go</code> from your <code>PATH</code> environment variable.
+        <p>If you installed Go with the macOS package, do this by removing the <code>/etc/paths.d/go</code> file.</p>
+      </li>
+      <li>If you manually added the Go bin directory (typically <code>$HOME/go/bin</code>) to your shell profile, for example by adding <code>export PATH="$PATH:$(go env GOPATH)/bin"</code>, remove that entry.</li>
+      <li>
+        Restart any open Terminal sessions for the changes to take effect.
+        <p><!-- for consistent spacing --></p>
+      </li>
+    </ol>
+  </div>
 
-<p>
-This is usually /usr/local/go.
-</p>
+  <div
+    role="tabpanel"
+    id="windows-tab"
+    class="TabSection-tabPanel"
+    aria-labelledby="windows"
+    hidden
+  >
+    <p>You can remove Go from Windows using one of the following methods:</p>
 
-</li>
+    <div class="windows-uninstall-method">
+      <h4>Method 1: Control Panel (Simplest)</h4>
+      <ol>
+        <li>Open Control Panel and double-click <strong>Add/Remove Programs</strong>.</li>
+        <li>Select <strong>Go Programming Language</strong>, click Uninstall, then follow the prompts.</li>
+      </ol>
+    </div>
 
-<li>Remove the Go bin directory from your <code>PATH</code> environment variable.
+    <div class="windows-uninstall-method">
+      <h4>Method 2: Command Line</h4>
+      <p>Uninstall using the command line by running the following command:</p>
+      <pre>msiexec /x go{{version}}.windows-{{cpu-arch}}.msi /q</pre>
+      <p>
+        <strong>Note:</strong> Using this process automatically removes Windows environment variables created by the original installation.
+      </p>
+    </div>
+  </div>
+</div>
 
-<p>
-Under Linux and FreeBSD, edit /etc/profile or $HOME/.profile. If you installed Go with the macOS package, remove the /etc/paths.d/go file.
-</p>
+<style>
+  #windows-tab {
+    padding: 1rem 1.5rem;
+  }
+  .windows-uninstall-method {
+    margin-bottom: 1.5rem;
+  }
+  .windows-uninstall-method h4 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+  }
+</style>
 
-</li>
-
-</ol>
-
-<h3 id="windows">Windows</h3>
-
-<p>
-The simplest way to remove Go is via Add/Remove Programs in the Windows control panel:
-</p>
-
-<ol>
-
-<li>In Control Panel, double-click <strong>Add/Remove Programs</strong>.</li>
-<li>In <strong>Add/Remove Programs</strong>, select <strong>Go Programming Language,</strong> click Uninstall, then follow the prompts.</li>
-
-</ol>
-
-<p>
-For removing Go with tools, you can also use the command line:
-</p>
-
-<ul>
-
-<li>Uninstall using the command line by running the following command:
-
-<pre>
-msiexec /x go{{version}}.windows-{{cpu-arch}}.msi /q
-</pre>
-
-<p>
-
-<strong>Note:</strong> Using this uninstall process for Windows will automatically remove Windows environment variables created by the original installation.
-</p>
-
-</li>
-
-</ul>
+<script src="/doc/manage-install.js"></script>
 

--- a/_content/doc/manage-install.html
+++ b/_content/doc/manage-install.html
@@ -134,7 +134,10 @@ These can be removed by deleting that directory. If you added this directory to 
       <li>Remove <code>/usr/local/go</code> from your <code>PATH</code> environment variable.
         <p>Under Linux and FreeBSD, edit <code>/etc/profile</code> or <code>$HOME/.profile</code>.</p>
       </li>
-      <li>If you manually added the Go bin directory (typically <code>$HOME/go/bin</code>) to your shell profile, for example by adding <code>export PATH="$PATH:$(go env GOPATH)/bin"</code>, remove that entry.</li>
+      <li>
+        If you manually added the Go bin directory (typically <code>$HOME/go/bin</code>) to your shell profile, for example by adding <code>export PATH="$PATH:$(go env GOPATH)/bin"</code>, remove that entry.
+        <p><!-- for consistent spacing --></p>
+      </li>
       <li>
         Restart any open terminal sessions for the changes to take effect.
         <p><!-- for consistent spacing --></p>
@@ -156,7 +159,10 @@ These can be removed by deleting that directory. If you added this directory to 
       <li>Remove <code>/usr/local/go</code> from your <code>PATH</code> environment variable.
         <p>If you installed Go with the macOS package, do this by removing the <code>/etc/paths.d/go</code> file.</p>
       </li>
-      <li>If you manually added the Go bin directory (typically <code>$HOME/go/bin</code>) to your shell profile, for example by adding <code>export PATH="$PATH:$(go env GOPATH)/bin"</code>, remove that entry.</li>
+      <li>
+        If you manually added the Go bin directory (typically <code>$HOME/go/bin</code>) to your shell profile, for example by adding <code>export PATH="$PATH:$(go env GOPATH)/bin"</code>, remove that entry.
+        <p><!-- for consistent spacing --></p>
+      </li>
       <li>
         Restart any open terminal sessions for the changes to take effect.
         <p><!-- for consistent spacing --></p>

--- a/_content/doc/manage-install.html
+++ b/_content/doc/manage-install.html
@@ -76,6 +76,14 @@ Go stores downloaded dependencies in the directory returned by <code>go env GOMO
 These can be removed with <code>go clean -modcache</code>.
 </p>
 
+<p>
+Go stores binaries installed with <code>go install</code> in the Go bin directory,
+as returned by <code>go env GOBIN</code> (which defaults to <code>$HOME/go/bin</code>).
+These can be removed by deleting that directory. If you added this directory to your
+<code>PATH</code> environment variable, you should also remove it.
+</p>
+
+
 <div id="os-install-tabs" class="TabSection js-tabSection">
   <div id="os-install-tablist" class="TabSection-tabList" role="tablist">
     <button
@@ -128,7 +136,7 @@ These can be removed with <code>go clean -modcache</code>.
       </li>
       <li>If you manually added the Go bin directory (typically <code>$HOME/go/bin</code>) to your shell profile, for example by adding <code>export PATH="$PATH:$(go env GOPATH)/bin"</code>, remove that entry.</li>
       <li>
-        Restart any open Terminal sessions for the changes to take effect.
+        Restart any open terminal sessions for the changes to take effect.
         <p><!-- for consistent spacing --></p>
       </li>
     </ol>
@@ -150,7 +158,7 @@ These can be removed with <code>go clean -modcache</code>.
       </li>
       <li>If you manually added the Go bin directory (typically <code>$HOME/go/bin</code>) to your shell profile, for example by adding <code>export PATH="$PATH:$(go env GOPATH)/bin"</code>, remove that entry.</li>
       <li>
-        Restart any open Terminal sessions for the changes to take effect.
+        Restart any open terminal sessions for the changes to take effect.
         <p><!-- for consistent spacing --></p>
       </li>
     </ol>

--- a/_content/doc/manage-install.js
+++ b/_content/doc/manage-install.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const tablist = document.querySelector('.TabSection-tabList');
+    if (!tablist) return;
+    const tabs = tablist.querySelectorAll('[role="tab"]');
+    const panels = document.querySelectorAll('[role="tabpanel"]');
+
+    tabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+            tabs.forEach(t => {
+                t.setAttribute('aria-selected', 'false');
+                t.setAttribute('tabindex', '-1');
+                t.classList.remove('active');
+            });
+            panels.forEach(p => p.setAttribute('hidden', ''));
+            
+            tab.setAttribute('aria-selected', 'true');
+            tab.setAttribute('tabindex', '0');
+            tab.classList.add('active');
+            
+            const controlsId = tab.getAttribute('aria-controls');
+            const panel = document.getElementById(controlsId);
+            if (panel) {
+                panel.removeAttribute('hidden');
+            }
+        });
+    });
+});


### PR DESCRIPTION
Update install.html to clarify adding the default Go bin directory
to PATH for Linux and macOS.

Restructure the uninstallation instructions in manage-install.html
to use OS-specific tab panels that match the install page.

Document GOBIN user data cleanup in manage-install.html and remind
users to remove the Go bin directory from their PATH during
uninstallation.

Standardize file paths with proper HTML code tags and lowercase
all occurrences of the word "terminal".

Fixes golang/go#39531
