### PR TITLE
solutions: update urfave/cli link to v3 GitHub URL

### DIFF
--- a/_content/solutions/clis.md
+++ b/_content/solutions/clis.md
@@ -157,7 +157,7 @@ Viper [supports nested structures](https://scene-si.org/2017/04/20/managing-conf
         url: https://pkg.go.dev/github.com/spf13/viper?tab=overview
         desc: A complete configuration solution for Go applications, designed to work within an app to handle configuration needs and formats
       - text: urfave/cli
-        url: https://pkg.go.dev/github.com/urfave/cli?tab=overview
+        url: https://github.com/urfave/cli
         desc: A minimal framework for creating and organizing command line Go applications
       - text: delve
         url: https://pkg.go.dev/github.com/go-delve/delve?tab=overview

--- a/_content/solutions/devops.md
+++ b/_content/solutions/devops.md
@@ -168,7 +168,7 @@ Go’s garbage collector means DevOps/SRE teams don’t have to worry about memo
         url: https://pkg.go.dev/github.com/spf13/viper?tab=overview
         desc: A complete configuration solution for Go applications, designed to work within an app to handle configuration needs and formats
       - text: urfave/cli
-        url: https://pkg.go.dev/github.com/urfave/cli?tab=overview
+        url: https://github.com/urfave/cli
         desc: A minimal framework for creating and organizing command line Go applications
   - title: Other projects
     items:


### PR DESCRIPTION
The pkg.go.dev URL redirects to v1.22.17 but the latest stable
version is v3.6.2. Update to the canonical GitHub URL which
automatically shows the latest version on pkg.go.dev.

Fixes golang/website#344