### PR TITLE
x/tour: clarify array and slice length explanation

### DIFF
--- a/tour/content/moretypes.article
+++ b/tour/content/moretypes.article
@@ -138,7 +138,7 @@ then builds a slice that references it:
 
 When slicing, you may omit the high or low bounds to use their defaults instead.
 
-The default is zero for the low bound and the length of the slice for the high bound.
+The default is zero for the low bound and the length of the array or slice for the high bound.
 
 For the array
 


### PR DESCRIPTION
Updates golang/go#79419

The current explanation of array and slice lengths in the Go tour can be misleading for beginners. This change clarifies that `len()` returns the number of elements for both arrays and slices, using more precise language in the example comment.
