### PR TITLE
_content/mobile-view: hide inactive navigation drawer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/_content/css/styles.css
+++ b/_content/css/styles.css
@@ -602,7 +602,10 @@ a.Footer-link--primary {
   right: 0;
   top: 0;
   transform: translateX(100%);
-  transition: transform 100ms ease-in-out;
+  transition:
+    transform 100ms ease-in-out,
+    visibility 0s linear 100ms;
+  visibility: hidden;
   width: 85%;
   z-index: 20;
 }
@@ -623,6 +626,8 @@ a.Footer-link--primary {
 
 .NavigationDrawer.is-active {
   transform: translateX(0);
+  transition: transform 100ms ease-in-out;
+  visibility: visible;
 }
 .NavigationDrawer-header {
   align-items: center;


### PR DESCRIPTION
Currently, the navigation drawer is still visible when inactive and is causing horizontal overflow issues in mobile UIs

<img width="746" height="975" alt="Screenshot from 2026-06-25 10-10-49" src="https://github.com/user-attachments/assets/63cc7401-18ad-49b6-8b04-93fa24e3ea56" />

This PR fixes that.