### PR TITLE
_content/doc/go1.24: fix typo

### DIFF
--- a/_content/doc/go1.24.md
+++ b/_content/doc/go1.24.md
@@ -304,7 +304,7 @@ The `synctest` package is experimental and must be enabled by
 setting `GOEXPERIMENT=synctest` at build time.
 The package API is subject to change in future releases.
 See [issue #67434](/issue/67434) for more information and
-to provide feeback.
+to provide feedback.
 
 ### Minor changes to the library {#minor_library_changes}
 


### PR DESCRIPTION
Single typo fix: "feeback" to "feedback".