### PR TITLE
tour: clarify conditionless switch benefits

### DIFF
--- a/_content/tour/flowcontrol.article
+++ b/_content/tour/flowcontrol.article
@@ -148,6 +148,7 @@ does not call `f` if `i==0`.)
 Switch without a condition is the same as `switch`true`.
 
 This construct can be a clean way to write long if-then-else chains.
+The cases can test conditions involving different variables; the first true case is selected.
 
 .play flowcontrol/switch-with-no-condition.go
 


### PR DESCRIPTION
Clarify that a conditionless switch lets cases test conditions involving different variables. This makes it a readable alternative to if-then-else chains when the conditions do not share a single switch value.

Keeps the existing time-of-day example intact.