### PR TITLE
_content/solutions: fix Uber case study link and description

### DIFF
--- a/_content/solutions/uber.md
+++ b/_content/solutions/uber.md
@@ -1,10 +1,10 @@
 ---
-title: "Uber - GPU-power analytics engine in Go"
-description: "AresDB [,written in Go,] is widely used at Uber to power our real-time data analytics dashboards, enabling us to make data-driven decisions at scale about myriad aspects of our business."
+title: "Uber - GPU-powered analytics engine in Go"
+description: "AresDB, written in Go, is widely used at Uber to power our real-time data analytics dashboards, enabling us to make data-driven decisions at scale about myriad aspects of our business."
 company: Uber
 logoSrc: uber_light.svg
 logoSrcDark: uber_dark.svg
 series: Case Studies
-link: https://eng.uber.com/aresdb/
+link: https://www.uber.com/blog/aresdb/
 inLandingPageGrid: true
 ---


### PR DESCRIPTION
The `eng.uber.com` domain has been retired and `https://eng.uber.com/aresdb/`
now returns 404 with no redirect. Two places on the site link to it:

- the Uber case study card on `/solutions/`
- the Uber logo in the "Companies using Go" grid on the home page
  (`_content/index.md`, which uses `.link` for entries with
  `inLandingPageGrid: true`)

Both currently send visitors to a dead page. This points them at the
article's current location, `https://www.uber.com/blog/aresdb/`, which
serves the same post ("Introducing AresDB: Uber's GPU-Powered Open Source,
Real-time Analytics Engine"). I used the locale-neutral path rather than the
`/US/en/` variant that `/en-US/blog/aresdb/` redirects to, to avoid pinning
the link to one locale.

Two small fixes to the same front matter while here:

- The `description` contained an unapplied editorial annotation,
  `AresDB [,written in Go,]`. `_content/solutions/case-studies.md` renders
  `{{.description}}` verbatim, so those brackets and stray commas were
  visible on the published page.
- `title` read "GPU-power analytics engine"; the linked article's own title
  is "GPU-**Powered**".

Tested with `go test ./...`. Two failures reproduce identically on master
and are unrelated to this change: `cmd/golangorg` `TestAll` reports a broken
link to `/LICENSE`, and `cmd/screentest` requires Google default credentials.
