### PR TITLE
_content/doc/tutorial: fix variable name typo in JSON tutorial

### DIFF
--- a/_content/doc/tutorial/json.md
+++ b/_content/doc/tutorial/json.md
@@ -317,7 +317,7 @@ type Version struct {
 }
 
 v := Version{1, 2, 3}
-b, err := json.Marshal(s)
+b, err := json.Marshal(v)
 ```
 
 This marshals as `{"Major":1,"Minor":2,"Patch":3}`, as expected based on the struct definition, but a version string like "1.2.3" would likely be a better representation for JSON consumers.


### PR DESCRIPTION
In the "Custom Marshal and Unmarshal" section of the JSON tutorial,
the code snippet initializes `v := Version{1, 2, 3}`, but incorrectly
passes `s` to `json.Marshal(s)`.

Change `json.Marshal(s)` to `json.Marshal(v)` to match the declared
variable.